### PR TITLE
TwilioRestResponse now handles HTTP 401 properly

### DIFF
--- a/twilio.php
+++ b/twilio.php
@@ -62,10 +62,14 @@
             if($this->HttpStatus != 204)
                 $this->ResponseXml = @simplexml_load_string($text);
             
-            if($this->IsError = ($status >= 400))
-                $this->ErrorMessage =
-                    (string)$this->ResponseXml->RestException->Message;
-            
+            if($this->IsError = ($status >= 400)) { 
+              if($status == 401) { 
+                $this->ErrorMessage = "Authentication required"; 
+              } else { 
+                $this->ErrorMessage = 
+                    (string)$this->ResponseXml->RestException->Message; 
+              } 
+            }
         }
         
     }


### PR DESCRIPTION
When TwilioRestResponse receives an HTTP 401, ResponseXml isn't an object. This commit handles 401 errors gracefully.
