### PR TITLE
add sample xml parsing code

### DIFF
--- a/Services/Twilio/CachingDataProxy.php
+++ b/Services/Twilio/CachingDataProxy.php
@@ -156,8 +156,10 @@ class Services_Twilio_CachingDataProxy
      */
     private function _load($object = null)
     {
-        $this->cache = $object !== null
-            ? $object
-            : $this->proxy->retrieveData($this->principal['sid']);
+        if ($object === null) {
+            $this->cache = $this->proxy->retrieveData($this->principal['sid']);
+        } else {
+            $this->cache = $object;
+        }
     }
 }

--- a/tests/TwilioTest.php
+++ b/tests/TwilioTest.php
@@ -6,6 +6,20 @@ class TwilioTest extends PHPUnit_Framework_TestCase {
     function tearDown() {
         m::close();
     }
+
+    function testXMLResponseParsing() {
+        $http = m::mock(new Services_Twilio_TinyHttp);
+        $http->shouldReceive('get')->once()
+            ->with('/2010-04-01/Accounts/AC123.xml')
+            ->andReturn(array(200, array('Content-Type' => 'application/xml'),
+                '<TwilioResponse><Account><Sid>AC123</Sid>
+                <FriendlyName>Irving Trube</FriendlyName></Account></TwilioResponse>'
+            ));
+        $client = new Services_Twilio('AC123', '123', '2010-04-01', $http, '.xml');
+        $this->assertEquals('AC123', $client->account->sid);
+        $this->assertEquals('Irving Trube', $client->account->friendly_name);
+    }
+
     function testNeedsRefining() {
         $http = m::mock(new Services_Twilio_TinyHttp);
         $http->shouldReceive('get')->once()


### PR DESCRIPTION
Here's an example of how to do xml parsing from the API - one problem is that the response representation is different for JSON and XML. I'm not sure of the best way to handle it. Check the code at the bottom of Services_Twilio for more info.
