### PR TITLE
Set version to known-good default regardless of input

### DIFF
--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -26,7 +26,7 @@ class Services_Twilio extends Services_Twilio_Resource
 
     protected $http;
     protected $version;
-    protected $versions = array('2010-04-01', '2008-08-01');
+    protected $versions = array('2008-08-01', '2010-04-01');
 
     /**
      * Constructor.
@@ -42,7 +42,8 @@ class Services_Twilio extends Services_Twilio_Resource
         $version = null,
         Services_Twilio_TinyHttp $_http = null
     ) {
-        $this->version = in_array($version, $this->versions) ? $version : $this->versions[0];
+        $this->version = in_array($version, $this->versions) ?
+                $version : $this->versions[count($this->versions)-1];
 
         if (null === $_http) {
             $_http = new Services_Twilio_TinyHttp(


### PR DESCRIPTION
tweaked the constructor to validate the specified version against a list of known-good versions;
this should resolve https://github.com/twilio/twilio-php/issues/42;
