### PR TITLE
Add autoload config to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
     },
     "require-dev": {
         "mockery/mockery": ">=0.7.2"
+    },
+    "autoload": {
+        "psr-0": {
+            "Services_Twilio": ""
+        }
     }
 }


### PR DESCRIPTION
That makes your package autoloadable by default. Which means ideally you should remove the autoload stuff from Services/Twilio.php - but I guess that's for a later step due to BC concerns..
