### PR TITLE
Add PHP warning if user does not have curl defined

### DIFF
--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -46,7 +46,7 @@ class Services_Twilio extends Services_Twilio_Resource
                 $version : end($this->versions);
 
         if (null === $_http) {
-            if (!defined('CURLOPT_USERAGENT')) {
+            if (!in_array('curl', get_loaded_extensions())) {
                 trigger_error("It looks like you do not have curl installed.\n". 
                     "Curl is required to make HTTP requests using the twilio-php\n" .
                     "library. For install instructions, visit the following page:\n" . 


### PR DESCRIPTION
The library _may_ work anyway, however it won't work that well and you won't be
able to make HTTP requests.

Assumes if you are passing in your own http object, you may be using some
different HTTP object and you are savvy enough to do what you want.
