### PR TITLE
Fix instance resource retrieving wrong URI

### DIFF
--- a/Services/Twilio/Resource.php
+++ b/Services/Twilio/Resource.php
@@ -17,11 +17,12 @@ abstract class Services_Twilio_Resource
     {
         $this->subresources = array();
         $this->client = $client;
-        $this->uri = $uri;
 
         foreach ($params as $name => $param) {
             $this->$name = $param;
         }
+
+        $this->uri = $uri;
         $this->init($client, $uri);
     }
 


### PR DESCRIPTION
Currently the instance resources are getting their URI set from the api (which includes the `.json` instruction) instead of building them programmatically. 

You can trigger the bug by retrieving an instance resource from the API either from the list resource or the instance resource, and then trying to retrieve it again. 
