### PR TITLE
Fix mute participants

### DIFF
--- a/Services/Twilio/ListResource.php
+++ b/Services/Twilio/ListResource.php
@@ -49,10 +49,10 @@ abstract class Services_Twilio_ListResource
      * @return Services_Twilio_InstanceResource An instance with properties 
      *      initialized to the values in the params array.
      */
-    public function getObjectFromJson($params)
+    public function getObjectFromJson($params, $idParam = "sid")
     {
-        if (isset($params->sid)) {
-            $uri = $this->uri . "/" . $params->sid;
+        if (isset($params->{$idParam})) {
+            $uri = $this->uri . "/" . $params->{$idParam};
         } else {
             $uri = $this->uri;
         }

--- a/Services/Twilio/Rest/Participants.php
+++ b/Services/Twilio/Rest/Participants.php
@@ -3,4 +3,8 @@
 class Services_Twilio_Rest_Participants
     extends Services_Twilio_ListResource
 {
+    /* Participants are identified by CallSid, not like PI123 */
+    public function getObjectFromJson($params, $idParam = "sid") {
+        return parent::getObjectFromJson($params, "call_sid");
+    }
 }

--- a/tests/ResourcesTest.php
+++ b/tests/ResourcesTest.php
@@ -245,57 +245,6 @@ class SMSMessagesTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class ConferencesTest extends PHPUnit_Framework_TestCase 
-{
-    protected $formHeaders = array('Content-Type' => 'application/x-www-form-urlencoded');
-    function testMuteParticipant() {
-        $http = m::mock(new Services_Twilio_TinyHttp);
-        $http->shouldReceive('get')->once()
-            ->with('/2010-04-01/Accounts/AC123/Conferences.json?Page=0&PageSize=50&Status=in-progress')
-            ->andReturn(array(200, array('Content-Type' => 'application/json'),
-                json_encode(array('conferences' => array(array(
-                    'sid' => 'CF123'
-                ))
-            ))
-        ));
-        $http->shouldReceive('get')->once()
-            ->with('/2010-04-01/Accounts/AC123/Conferences/CF123/Participants.json?Page=0&PageSize=50')
-            ->andReturn(array(200, array('Content-Type' => 'application/json'),
-                json_encode(array('participants' => array(array(
-                    'call_sid' => 'CA345'
-                ))
-            ))
-        ));
-        /* Participants has no 'sid' parameter */
-        $http->shouldReceive('post')->once()
-            ->with('/2010-04-01/Accounts/AC123/Conferences/CF123/Participants/CA345.json', 
-                $this->formHeaders, 'Muted=true')
-            ->andReturn(array(200, array('Content-Type' => 'application/json'),
-                json_encode(array('participants' => array(array(
-                    'call_sid' => 'CA345'
-                ))
-            ))
-        ));
-        $http->shouldReceive('get')->once()
-            ->with('/2010-04-01/Accounts/AC123/Conferences.json?Page=1&PageSize=50&Status=in-progress')
-            ->andReturn(array(400, array('Content-Type' => 'application/json'),
-                '{"status":400,"message":"foo", "code": "20006"}'
-            ));
-
-        $client = new Services_Twilio('AC123', '123', '2010-04-01', $http);
-        foreach($client->account->conferences->getIterator(0, 50, array('Status' => 'in-progress')) as $conference) {
-            $participants = $conference->participants->getPage(0, 50)->participants;
-            foreach ($participants as $p) {
-                $p->mute();
-            }
-        }
-    }
-
-    function tearDown() {
-        m::close();
-    }
-}
-
 class CallsTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/TwilioTest.php
+++ b/tests/TwilioTest.php
@@ -268,7 +268,7 @@ class TwilioTest extends PHPUnit_Framework_TestCase {
                 '/2010-04-01/Accounts/AC123/Conferences/CF123/Participants.json?Page=0&PageSize=10')
                 ->andReturn(array(200, array('Content-Type' => 'application/json'),
                     json_encode(array(
-                        'participants' => array(array('sid' => 'CA123'))
+                        'participants' => array(array('call_sid' => 'CA123'))
                     ))
                 ));
         $http->shouldReceive('post')->once()


### PR DESCRIPTION
overrides `getObjectFromJson` to take a parameter in case the id parameter is not named
'sid' but instead named something silly like 'call_sid', which it is for Participants. Also deletes the
duplicate test and fixes the old, broken test.
