### PR TITLE
Missing an ending parens in the conference TwiML example.

### DIFF
--- a/docs/usage/twiml.rst
+++ b/docs/usage/twiml.rst
@@ -200,7 +200,7 @@ Conference
         "startConferenceOnEnter" => "true",
         "muted" => "true",
         "beep" => "false",
-    );
+    ));
     print $response;
 
 .. code-block:: xml


### PR DESCRIPTION
Missing an ending parens in the conference TwiML example.
