### PR TITLE
install travis-ci test deps using composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ php:
     - 5.3
     - 5.4
 script: "make test"
-before_install: "bash travis_install.bash"
+before_install: "composer install --dev"

--- a/travis_install.bash
+++ b/travis_install.bash
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# A setup script for installing the unit test dependencies
-
-pyrus channel-discover pear.survivethedeepend.com
-pyrus install deepend/Mockery
-
-phpenv rehash
-


### PR DESCRIPTION
the travis-ci tests now run in 20 seconds instead of 83 seconds.
