### PR TITLE
To string

### DIFF
--- a/Services/Twilio/Resource.php
+++ b/Services/Twilio/Resource.php
@@ -103,6 +103,13 @@ abstract class Services_Twilio_Resource {
         return $this->$key;
     }
 
+    /**
+     * Print a JSON representation of this object. Strips the HTTP client 
+     * before returning.
+     *
+     * Note that echoing an object before an HTTP request has been made to 
+     * "fill in" its properties may return an empty object
+     */
     public function __toString() {
         $out = array();
         foreach ($this as $key => $value) {


### PR DESCRIPTION
Allows you to echo() resources and get back JSON representations of the object. 

The current behavior is to throw a catchable fatal error, stating that the object in question couldn't be converted to a string. Now we'll return a JSON value instead of erroring in this case.

``` php
<?php

$client = new Services_Twilio('AC123', '123');
foreach ($client->account->sms_messages as $message) {
    echo $message;
    break;
}
```

will print

```
{"subresources":"Array","sid":"SM3efd9ff19b11be1ccbd8af599f60aaaa","date_created":"Sat, 24 Nov 2012 00:00:04 +0000","date_updated":"Sat, 24 Nov 2012 00:00:04 +0000","date_sent":"Sat, 24 Nov 2012 00:00:04 +0000","account_sid":"AC58f1e8f2b1c6b88ca90a012a4aaaaaaa","to":"+14105551234","from":"+14105556789","body":"hello","status":"sent","direction":"outbound-api","price":"-0.01000","api_version":"2010-04-01","uri":"\/2010-04-01\/Accounts\/AC58f1e8f2b1c6b88ca90a012a4aaaaaaa\/SMS\/Messages\/SM3efd9ff19b11be1ccbd8af599aaaaaaa"}
```
