### PR TITLE
Fix special character support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Library Documentation")
 
 ## Prerequisites
 
-* PHP >= 5.2.1
+* PHP >= 5.2.3
 * The PHP JSON extension
 
 ## Reporting Issues

--- a/Services/Twilio/Twiml.php
+++ b/Services/Twilio/Twiml.php
@@ -92,15 +92,13 @@ class Services_Twilio_Twiml
          * want to break their existing code by turning their &amp;'s into 
          * &amp;amp;
          *
-         * So we end up with the following matrix:
+         * We also want to use numeric entities, not named entities so that we
+         * are fully compatible with XML
          *
-         * We want & to turn into &amp; before passing to addChild
-         * We want &amp; to stay as &amp; before passing to addChild
-         *
-         * The following line accomplishes the desired behavior.
+         * The following lines accomplishes the desired behavior.
          */
-        $normalized = htmlentities($noun, null, null, false);
-        //then escape it again
+        $decoded = html_entity_decode($noun, ENT_COMPAT, 'UTF-8');
+        $normalized = htmlspecialchars($decoded, ENT_COMPAT, 'UTF-8', false);
         $child = empty($noun)
             ? $this->element->addChild(ucfirst($verb))
             : $this->element->addChild(ucfirst($verb), $normalized);

--- a/tests/TwimlTest.php
+++ b/tests/TwimlTest.php
@@ -47,6 +47,30 @@ class TwimlTest extends PHPUnit_Framework_TestCase {
         $this->assertXmlStringEqualsXmlString($expected, $r);
     }
     
+    public function testSayUTF8() {
+        $r = new Services_Twilio_Twiml();
+        $r->say("é tü & må");
+        $expected = '<Response><Say>'
+            . '&#xE9; t&#xFC; &amp; m&#xE5;</Say></Response>';
+        $this->assertXmlStringEqualsXmlString($expected, $r);
+    }
+    
+    public function testSayNamedEntities() {
+        $r = new Services_Twilio_Twiml();
+        $r->say("&eacute; t&uuml; &amp; m&aring;");
+        $expected = '<Response><Say>'
+            . '&#xE9; t&#xFC; &amp; m&#xE5;</Say></Response>';
+        $this->assertXmlStringEqualsXmlString($expected, $r);
+    }
+    
+    public function testSayNumericEntities() {
+        $r = new Services_Twilio_Twiml();
+        $r->say("&#xE9; t&#xFC; &amp; m&#xE5;");
+        $expected = '<Response><Say>'
+            . '&#xE9; t&#xFC; &amp; m&#xE5;</Say></Response>';
+        $this->assertXmlStringEqualsXmlString($expected, $r);
+    }
+    
     public function testPlayBasic() {   
         $r = new Services_Twilio_Twiml();
         $r->play("hello-monkey.mp3");


### PR DESCRIPTION
The current version of the Twilio PHP library will take input passed in and run it through the PHP `htmlentities` function. This produces "named" character entities in the output. Named character entities and XML don't get along. Only the 'quot', 'amp', 'apos', 'lt', and 'gt' entities are defined.

This change replaces the `htmlentities` call with an process that decodes the input and then runs it through `htmlspecialchars` to produce "numeric" entities instead.

This should accommodate most western character sets. Non standard (to htmlspecialchars) multi-byte character sets will fail silently in Twilio (ie: say nothing) instead of throwing an application error.
## Desired text

```
é tü & må
```
## Old and busted

Twilio returns "An application error has occurred" with the actual logged error being "Error on line 2 of document : The entity "Atilde" was referenced, but not declared. Please ensure that the response body is a valid XML document."

```
<?xml version="1.0" encoding="UTF-8"?>
<Response><Say>&Atilde;&copy; t&Atilde;&frac14; &amp; m&Atilde;&yen;</Say></Response>
```
## New Hotness

Twilio properly pronounces the characters.

```
<?xml version="1.0" encoding="UTF-8"?>
<Response><Say>&#xE9; t&#xFC; &amp; m&#xE5;</Say></Response>
```
## Test

The unit tests have been updated to test for desired output, but here's a quick test that can be run to observe the output:

```
<?php

require('/path/to/twilio-php/Services/Twilio.php');

$lines = array(
    'é tü & må', // raw UTF8
    '&eacute; t&uuml; &amp; m&aring;', // html named entities
    '&#xE9; t&#xFC; &amp; m&#xE5;', // html numeric entities
);

$response = new Services_Twilio_Twiml;

foreach ($lines as $line) {
    $response->say($line);
}

# All 3 say verbs in response should match
echo $response;
```
## New Requirements

Library now requires PHP 5.2.3 (formerly 5.2.1) to support the non-double encoding flag on the php function `htmlspecialchars`
