### PR TITLE
Fixed "Undefined property: stdClass::$status" in _processResponse()

### DIFF
--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -213,8 +213,8 @@ class Services_Twilio extends Services_Twilio_Resource
             return $decoded;
         }
         throw new Services_Twilio_RestException(
-            (int)$decoded->status,
-            $decoded->message,
+            isset($decoded->status) ? (int)$decoded->status : $status,
+            isset($decoded->message) ? $decoded->message : null,
             isset($decoded->code) ? $decoded->code : null,
             isset($decoded->more_info) ? $decoded->more_info : null
         );


### PR DESCRIPTION
I'm trying to update the Front of the queue with the following code:

``` php
$frontCall = $this->getTwilio()->account->queues->get($queueSid)->members->front();
$frontCall->update(array(
    'Url'    => '/answer.xml'
    'Method' => 'POST'
));
```

Works fine, if the queue is not empty. But when there's no one in the queue, I get this error:

``` text
Notice: Undefined property: stdClass::$status in /Volumes/www/tolkenselect/vendor/twilio/sdk/Services/Twilio.php line 216
```

This PR fixes this.
