### PR TITLE
return 'static' object in Services_Twilio_Twiml::_call method

### DIFF
--- a/Services/Twilio/Twiml.php
+++ b/Services/Twilio/Twiml.php
@@ -115,7 +115,7 @@ class Services_Twilio_Twiml
             }
             $child->addAttribute($name, $value);
         }
-        return new self($child);
+        return new static($child);
     }
 
     /**


### PR DESCRIPTION
sometimes I want to override __call method for some reason. For example I always want to call say method with language option "'language' => 'ja-jp');".

``` php
class Custom_Services_Twilio_Twiml extends Services_Twilio_Twiml
{

    private $_sayOptions = ['voice' => 'woman', 'language' => 'ja-jp'];

    public function __call($verb, array $args)
    {
        if ($verb === 'say') {
            $args[] = $this->_sayOptions;
        }

        return parent::__call($verb, $args);
    }
}
```
