### PR TITLE
removed preg_replace with /e modifier

### DIFF
--- a/Services/Twilio/Resource.php
+++ b/Services/Twilio/Resource.php
@@ -75,7 +75,7 @@ abstract class Services_Twilio_Resource {
             'return strtolower(strlen("$matches[1]") ? "$matches[1]_$matches[2]" : "$matches[2]");');
 
         return preg_replace_callback(
-            '/(^|[a-z])([A-Z])/e',
+            '/(^|[a-z])([A-Z])/',
             $callback,
             $word
         );


### PR DESCRIPTION
switched from using preg_replace with /e as it's deprecated in 5.5 and not supported in some environments;
while an anonymous function would work, by using create_function we can stay 5.2 compatible;
necessary for Google App Engine compatibility;
