### PR TITLE
Correct and improve the code example for validating a request from Twili...

### DIFF
--- a/docs/usage/validation.rst
+++ b/docs/usage/validation.rst
@@ -23,18 +23,36 @@ The below example will print out a confirmation message if the request is actual
 
 .. code-block:: php
 
-    $token = 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY';
-
-    $validator = new Services_Twilio_RequestValidator($token);
-
-    $url = "http://www.example.com/request/url";
-    $postVars = array();
-    $signature = "X-Twilio-Signature header value";
-
+    // Your auth token from twilio.com/user/account
+    $authToken = '12345';
+ 
+    // Download the twilio-php library from twilio.com/docs/php/install, include it 
+    // here
+    require_once('/path/to/twilio-php/Services/Twilio.php');
+    $validator = new Services_Twilio_RequestValidator($authToken);
+ 
+    // The Twilio request URL. You may be able to retrieve this from 
+    // $_SERVER['SCRIPT_URI']
+    $url = 'https://mycompany.com/myapp.php?foo=1&bar=2';
+ 
+    // The post variables in the Twilio request. You may be able to use 
+    // $postVars = $_POST
+    $postVars = array(
+        'CallSid' => 'CA1234567890ABCDE',
+        'Caller' => '+14158675309',
+        'Digits' => '1234',
+        'From' => '+14158675309',
+        'To' => '+18005551212'
+    );
+ 
+    // The X-Twilio-Signature header - in PHP this should be 
+    // $_SERVER["HTTP_X_TWILIO_SIGNATURE"];
+    $signature = 'RSOYDt4T1cUTdK1PDd93/VVr8B8=';
+ 
     if ($validator->validate($signature, $url, $postVars)) {
         echo "Confirmed to have come from Twilio.";
     } else {
-        echo "NOT VALID.  It might have been spoofed!";
+        echo "NOT VALID. It might have been spoofed!";
     }
 
 Trailing Slashes


### PR DESCRIPTION
The previous code example for validating a request from Twilio was a bit confusing and incomplete, for example not populating the post variables array and giving a hint as to where to get the signature from. This new example mirrors the better one that is currently reference in the docs on twilio.com.
