### PR TITLE
fixed the case where a 4xx error would not populate the exception properly and we'd end up with a wrong message

### DIFF
--- a/Services/Twilio/HttpStream.php
+++ b/Services/Twilio/HttpStream.php
@@ -53,6 +53,7 @@ class Services_Twilio_HttpStream {
         }
 
         $request_options['http']['method'] = strtoupper($name);
+        $request_options['http']['ignore_errors'] = true;
 
         if ($this->debug) {
             error_log(var_export($request_options, true));


### PR DESCRIPTION
Credit goes to CostaC for his solution described here:
https://github.com/twilio/twilio-php/issues/133#issuecomment-21303014
