### PR TITLE
PHP 5.2 doesn't know `new static`

### DIFF
--- a/Services/Twilio/Twiml.php
+++ b/Services/Twilio/Twiml.php
@@ -102,7 +102,7 @@ class Services_Twilio_Twiml {
          */
         $decoded = html_entity_decode($noun, ENT_COMPAT, 'UTF-8');
         $normalized = htmlspecialchars($decoded, ENT_COMPAT, 'UTF-8', false);
-        $child = empty($noun)
+        $child = !(is_scalar($noun) && strlen($noun))
             ? $this->element->addChild(ucfirst($verb))
             : $this->element->addChild(ucfirst($verb), $normalized);
         foreach ($attrs as $name => $value) {

--- a/tests/TwimlTest.php
+++ b/tests/TwimlTest.php
@@ -23,6 +23,27 @@ class TwimlTest extends PHPUnit_Framework_TestCase {
         $expected = '<Response><Say>Hello Monkey</Say></Response>';
         $this->assertXmlStringEqualsXmlString($expected, $r);
     }
+	
+    public function testSayTrue() {   
+        $r = new Services_Twilio_Twiml();
+        $r->say(true);
+        $expected = '<Response><Say>1</Say></Response>';
+        $this->assertXmlStringEqualsXmlString($expected, $r);
+    }
+	
+    public function testSayFalse() {   
+        $r = new Services_Twilio_Twiml();
+        $r->say(false);
+        $expected = '<Response><Say></Say></Response>';
+        $this->assertXmlStringEqualsXmlString($expected, $r);
+    }
+	
+    public function testSayFalsy() {   
+        $r = new Services_Twilio_Twiml();
+        $r->say("0");
+        $expected = '<Response><Say>0</Say></Response>';
+        $this->assertXmlStringEqualsXmlString($expected, $r);
+    }
     
     public function testSayLoopThree() {
         $r = new Services_Twilio_Twiml();


### PR DESCRIPTION
The Twilio PHP Helper library specifies PHP 5.2.3 as a minimum required version but late static binding wasn't introduced until version 5.3.

Use `new self` to stay backwards compatible.

I don't see anything extending `Services_Twilio_Twiml` so this should have no negative side effects.

This was found by an OpenVBX user @barth907 twilio/openvbx#281
