### PR TITLE
Use constant time string comparison to avoid timing attacks.

### DIFF
--- a/Services/Twilio/RequestValidator.php
+++ b/Services/Twilio/RequestValidator.php
@@ -9,7 +9,7 @@ class Services_Twilio_RequestValidator
     {
         $this->AuthToken = $token;
     }
-    
+
     public function computeSignature($url, $data = array())
     {
         // sort the array by keys
@@ -19,7 +19,7 @@ class Services_Twilio_RequestValidator
         // with no delimiters
         foreach($data as $key => $value)
             $url .= "$key$value";
-            
+
         // This function calculates the HMAC hash of the data with the key
         // passed in
         // Note: hash_hmac requires PHP 5 >= 5.1.2 or PECL hash:1.1-1.5
@@ -29,8 +29,26 @@ class Services_Twilio_RequestValidator
 
     public function validate($expectedSignature, $url, $data = array())
     {
-        return $this->computeSignature($url, $data)
-            == $expectedSignature;
+        $signature = $this->computeSignature($url, $data);
+        return $this->secureStringCompare($expectedSignature, $signature);
+    }
+
+    // Constant time string comparison to avoid timing attacks. Function
+    // borrowed from ZendFramework.
+    // https://github.com/zendframework/zf2/blob/master/library/Zend/Crypt/Utils.php
+    private function secureStringCompare($expected, $actual)
+    {
+        $expected = (string) $expected;
+        $actual = (string) $actual;
+        $lenExpected = strlen($expected);
+        $lenActual = strlen($actual);
+        $len = min($lenExpected, $lenActual);
+        $result = 0;
+        for ($i = 0; $i < $len; $i++) {
+            $result |= ord($expected[$i]) ^ ord($actual[$i]);
+        }
+        $result |= $lenExpected ^ $lenActual;
+        return ($result === 0);
     }
 
 }


### PR DESCRIPTION
Inspired by [twilio-java/#158](https://github.com/twilio/twilio-java/pull/158) (and [twilio-ruby/#116](https://github.com/twilio/twilio-ruby/pull/116)).

This is my first PHP for a long, long while so be gentle!
