### PR TITLE
Update RequestValidator.php

### DIFF
--- a/Services/Twilio/RequestValidator.php
+++ b/Services/Twilio/RequestValidator.php
@@ -46,7 +46,7 @@ class Services_Twilio_RequestValidator
         $res = 0;
         $len = \strlen($a);
         for ($i = 0; $i < $len; ++$i) {
-            $res |= $a[$i] ^ $b[$i];
+            $res |= \ord($a[$i]) ^ \ord($b[$i]);
         }
         return $res === 0;
     }

--- a/Services/Twilio/RequestValidator.php
+++ b/Services/Twilio/RequestValidator.php
@@ -29,8 +29,26 @@ class Services_Twilio_RequestValidator
 
     public function validate($expectedSignature, $url, $data = array())
     {
-        return $this->computeSignature($url, $data)
-            == $expectedSignature;
+        return $this->hash_equals(
+            $this->computeSignature($url, $data),
+            $expectedSignature
+        );
+    }
+    
+    public function hash_equals($a, $b)
+    {
+        if (\function_exists('hash_equals')) {
+            return \hash_equals($a, $b);
+        }
+        if (\strlen($a) !== \strlen($b)) {
+            return false;
+        }
+        $res = 0;
+        $len = \strlen($a);
+        for ($i = 0; $i < $len; ++$i) {
+            $res |= $a[$i] ^ $b[$i];
+        }
+        return $res === 0;
     }
 
 }


### PR DESCRIPTION
The current implementation of `Service_Twilio_RequestValidator` has a couple of security concerns that are remotely exploitable:
1. Signatures are compared using the non-strict `==` operator (See: https://eval.in/108854 for why this is bad in PHP)
2. Invalid signatures will take longer to fail the more leftmost bytes are correct (this is called a timing attack, and can be used to brute-force a signature).

This patch polyfills a `hash_equals()` implementation in case PHP < 5.6.0 in installed; otherwise, it uses the native implementation.
