### PR TITLE
Implemented message deleting

### DIFF
--- a/Services/Twilio/InstanceResource.php
+++ b/Services/Twilio/InstanceResource.php
@@ -32,7 +32,17 @@ abstract class Services_Twilio_InstanceResource extends Services_Twilio_Resource
         $this->updateAttributes($decamelizedParams);
     }
 
-    /*
+    /**
+     * Make a request to delete the specified resource.
+     *
+     * :rtype: boolean
+     */
+    public function delete()
+    {
+        return $this->client->deleteData($this->uri);
+    }
+
+    /**
      * Add all properties from an associative array (the JSON response body) as
      * properties on this instance resource, except the URI
      *

--- a/Services/Twilio/InstanceResource.php
+++ b/Services/Twilio/InstanceResource.php
@@ -33,16 +33,6 @@ abstract class Services_Twilio_InstanceResource extends Services_Twilio_Resource
     }
 
     /**
-     * Make a request to delete the specified resource.
-     *
-     * :rtype: boolean
-     */
-    public function delete()
-    {
-        return $this->client->deleteData($this->uri);
-    }
-
-    /**
      * Add all properties from an associative array (the JSON response body) as
      * properties on this instance resource, except the URI
      *

--- a/Services/Twilio/Rest/Call.php
+++ b/Services/Twilio/Rest/Call.php
@@ -103,4 +103,14 @@ class Services_Twilio_Rest_Call extends Services_Twilio_InstanceResource {
             'feedback'
         );
     }
+
+    /**
+     * Make a request to delete the specified resource.
+     *
+     * :rtype: boolean
+     */
+    public function delete()
+    {
+        return $this->client->deleteData($this->uri);
+    }
 }

--- a/Services/Twilio/Rest/Message.php
+++ b/Services/Twilio/Rest/Message.php
@@ -54,5 +54,15 @@ class Services_Twilio_Rest_Message extends Services_Twilio_InstanceResource {
         $postParams = array('Body' => '');
         self::update($postParams);
     }
+
+    /**
+     * Make a request to delete the specified resource.
+     *
+     * :rtype: boolean
+     */
+    public function delete()
+    {
+        return $this->client->deleteData($this->uri);
+    }
 }
 


### PR DESCRIPTION

This allows you to delete a message (or call) and makes this code work as expected:

https://github.com/twilio/twilio-php/commit/159960c415a7b296349d3b7e68ef788ca28d24b2#diff-74d2e3a0717d829d8824221b07bd8e5c

Note: This might be better implemented on the Message and Call objects as the delete() doesn't apply to all resources.