### PR TITLE
Correct the endpoint for the Lookups API

### DIFF
--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -531,4 +531,15 @@ class Lookups_Services_Twilio extends Base_Services_Twilio
 		return $query_path;
 	}
 
+    /**
+     * Get the base URI for this client.
+     *
+     * :return: base URI
+     * :rtype: string
+     */
+    protected function _getBaseUri()
+    {
+        return 'https://lookups.twilio.com';
+    }
+
 }


### PR DESCRIPTION
The Lookups API is currently unusable with a range of confusing errors. Upon looking further, you're pointing it at the wrong endpoint.