### PR TITLE
Make Lookups_Services_Twilio available through composer.

### DIFF
--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -8,7 +8,9 @@
 
 function Services_Twilio_autoload($className)
 {
-    if (substr($className, 0, 15) != 'Services_Twilio' && substr($className, 0, 26) != 'TaskRouter_Services_Twilio') {
+    if (substr($className, 0, 15) != 'Services_Twilio' 
+        && substr($className, 0, 26) != 'TaskRouter_Services_Twilio'
+        && substr($className, 0, 23) != 'Lookups_Services_Twilio') {
         return false;
     }
     $file = str_replace('_', '/', $className);

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     },
     "autoload": {
         "psr-0": {
-            "Services_Twilio": ""
+            "Services_Twilio": "",
+            "Lookups_Services_Twilio": ""
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "autoload": {
         "psr-0": {
             "Services_Twilio": "",
-            "Lookups_Services_Twilio": ""
+            "Lookups_Services_Twilio": "",
+            "TaskRouter_Services_Twilio": ""
         }
     }
 }


### PR DESCRIPTION
If you install twillio-php through composer it seems to be impossible to access the Lookups_Services_Twilio class. This fix should now make it possible to grab it.