### PR TITLE
Add 5.6/7/HHVM allowing for appropriate failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,12 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
+    - 7.0
+    - hhvm
+matrix:
+    allow_failures:
+        - 7.0
+        - hhvm
 script: "make test"
 before_install: "composer install --dev"


### PR DESCRIPTION
5.6 is current stable, so we should have that at the minimum. Since 7 is coming up we should check compatibility, and HHVM since a lot of people use it in production (but both should be allowed to fail).