### PR TITLE
Loading Reservations under a Worker by default in TaskRouter JS SDK

### DIFF
--- a/Services/Twilio/CapabilityTaskRouter.php
+++ b/Services/Twilio/CapabilityTaskRouter.php
@@ -55,12 +55,15 @@ class Services_Twilio_TaskRouter_Capability extends Services_Twilio_API_Capabili
 		}else if(substr($this->channelId,0,2) == 'WK') {
 			$this->resourceUrl = $this->baseUrl.'/Workers/'.$this->channelId;
 
-			//add permissions to fetch the list of activities and list of worker reservations
+			//add permissions to fetch the list of activities, tasks and worker reservations
 			$activityUrl = $this->baseUrl.'/Activities';
 			$this->allow($activityUrl, "GET", null, null);
 
-			$reservationsUrl = $this->baseUrl.'/Tasks/**';
-			$this->allow($reservationsUrl, "GET", null, null);
+			$tasksUrl = $this->baseUrl.'/Tasks/**';
+			$this->allow($tasksUrl, "GET", null, null);
+
+			$workerReservationsUrl = $this->resourceUrl.'/Reservations/**';
+			$this->allow($workerReservationsUrl, "GET", null, null);
 
 		}else if(substr($this->channelId,0,2) == 'WQ') {
 			$this->resourceUrl = $this->baseUrl.'/TaskQueues/'.$this->channelId;
@@ -177,19 +180,22 @@ class Services_Twilio_TaskRouter_Capability extends Services_Twilio_API_Capabili
  */
 class Services_Twilio_TaskRouter_Worker_Capability extends Services_Twilio_TaskRouter_Capability
 {
-	private $reservationsUrl;
+	private $tasksUrl;
+	private $workerReservationsUrl;
 	private $activityUrl;
 
 	public function __construct($accountSid, $authToken, $workspaceSid, $workerSid, $overrideBaseUrl = null, $overrideBaseWSUrl = null)
 	{
 		parent::__construct($accountSid, $authToken, $workspaceSid, $workerSid, null, $overrideBaseUrl, $overrideBaseWSUrl);
 
-		$this->reservationsUrl = $this->baseUrl.'/Tasks/**';
+		$this->tasksUrl = $this->baseUrl.'/Tasks/**';
 		$this->activityUrl = $this->baseUrl.'/Activities';
+		$this->workerReservationsUrl = $this->resourceUrl.'/Reservations/**';
 
-		//add permissions to fetch the list of activities and list of worker reservations
+		//add permissions to fetch the list of activities, tasks, and worker reservations
 		$this->allow($this->activityUrl, "GET", null, null);
-		$this->allow($this->reservationsUrl, "GET", null, null);
+		$this->allow($this->tasksUrl, "GET", null, null);
+		$this->allow($this->workerReservationsUrl, "GET", null, null);
 	}
 
 	protected function setupResource() {
@@ -207,7 +213,8 @@ class Services_Twilio_TaskRouter_Worker_Capability extends Services_Twilio_TaskR
 		$method = 'POST';
 		$queryFilter = array();
 		$postFilter = array();
-		$this->allow($this->reservationsUrl, $method, $queryFilter, $postFilter);
+		$this->allow($this->tasksUrl, $method, $queryFilter, $postFilter);
+		$this->allow($this->workerReservationsUrl, $method, $queryFilter, $postFilter);
 	}
 }
 

--- a/tests/CapabilityTaskRouterTest.php
+++ b/tests/CapabilityTaskRouterTest.php
@@ -1,0 +1,224 @@
+<?php
+
+require_once 'Twilio/CapabilityTaskRouter.php';
+
+class CapabilityTaskRouter extends PHPUnit_Framework_TestCase {
+
+	public function testDefaultWorker()
+	{
+		$workerCapability = new Services_Twilio_TaskRouter_Worker_Capability('AC123', 'foobar', 'WS456', 'WK789');
+		$token = $workerCapability->generateToken();
+		$payload = JWT::decode($token, 'foobar');
+
+		$this->assertEquals('AC123', $payload->iss);
+		$this->assertEquals('AC123', $payload->account_sid);
+		$this->assertEquals('WK789', $payload->channel);
+		$this->assertEquals('WS456', $payload->workspace_sid);
+		$this->assertEquals('WK789', $payload->worker_sid);
+		$this->assertEquals('v1', $payload->version);
+
+		$policies = $payload->policies;
+		$this->assertEquals(6, count($policies));
+
+		$this->assertEquals('https://event-bridge.twilio.com/v1/wschannels/AC123/WK789', $policies[0]->url);
+		$this->assertEquals('GET', $policies[0]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[0]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[0]);
+		$this->assertEquals(true, $policies[0]->allow);
+
+		$this->assertEquals('https://event-bridge.twilio.com/v1/wschannels/AC123/WK789', $policies[1]->url);
+		$this->assertEquals('POST', $policies[1]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[1]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[1]);
+		$this->assertEquals(true, $policies[1]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789', $policies[2]->url);
+		$this->assertEquals('GET', $policies[2]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[2]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[2]);
+		$this->assertEquals(true, $policies[2]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities', $policies[3]->url);
+		$this->assertEquals('GET', $policies[3]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[3]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[3]);
+		$this->assertEquals(true, $policies[3]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**', $policies[4]->url);
+		$this->assertEquals('GET', $policies[4]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[4]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[4]);
+		$this->assertEquals(true, $policies[4]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**', $policies[5]->url);
+		$this->assertEquals('GET', $policies[5]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[5]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[5]);
+		$this->assertEquals(true, $policies[5]->allow);
+    }
+
+	public function testAllowWorkerUpdates()
+	{
+		$workerCapability = new Services_Twilio_TaskRouter_Worker_Capability('AC123', 'foobar', 'WS456', 'WK789');
+		$workerCapability->allowActivityUpdates();
+		$token = $workerCapability->generateToken();
+		$payload = JWT::decode($token, 'foobar');
+
+		$this->assertEquals('AC123', $payload->iss);
+		$this->assertEquals('AC123', $payload->account_sid);
+		$this->assertEquals('WK789', $payload->channel);
+		$this->assertEquals('WS456', $payload->workspace_sid);
+		$this->assertEquals('WK789', $payload->worker_sid);
+		$this->assertEquals('v1', $payload->version);
+
+		$policies = $payload->policies;
+		$this->assertEquals(7, count($policies));
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789', $policies[6]->url);
+		$this->assertEquals('POST', $policies[6]->method);
+		$this->assertEquals(new stdClass(), $policies[6]->query_filter);
+		$this->assertEquals(true, $policies[6]->post_filter->ActivitySid->required);
+		$this->assertEquals(true, $policies[6]->allow);
+	}
+
+	public function testAllowReservationUpdates()
+	{
+		$workerCapability = new Services_Twilio_TaskRouter_Worker_Capability('AC123', 'foobar', 'WS456', 'WK789');
+		$workerCapability->allowActivityUpdates();
+		$workerCapability->allowReservationUpdates();
+		$token = $workerCapability->generateToken();
+		$payload = JWT::decode($token, 'foobar');
+
+		$this->assertEquals('AC123', $payload->iss);
+		$this->assertEquals('AC123', $payload->account_sid);
+		$this->assertEquals('WK789', $payload->channel);
+		$this->assertEquals('WS456', $payload->workspace_sid);
+		$this->assertEquals('WK789', $payload->worker_sid);
+		$this->assertEquals('v1', $payload->version);
+
+		$policies = $payload->policies;
+		$this->assertEquals(9, count($policies));
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**', $policies[7]->url);
+		$this->assertEquals('POST', $policies[7]->method);
+		$this->assertEquals(new stdClass(), $policies[7]->query_filter);
+		$this->assertEquals(new stdClass(), $policies[7]->post_filter);
+		$this->assertEquals(true, $policies[7]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**', $policies[8]->url);
+		$this->assertEquals('POST', $policies[8]->method);
+		$this->assertEquals(new stdClass(), $policies[8]->query_filter);
+		$this->assertEquals(new stdClass(), $policies[8]->post_filter);
+		$this->assertEquals(true, $policies[8]->allow);
+	}
+
+	public function testDefaultWorkspace()
+	{
+		$workspaceCapability = new Services_Twilio_TaskRouter_Workspace_Capability('AC123', 'foobar', 'WS456');
+		$token = $workspaceCapability->generateToken();
+		$payload = JWT::decode($token, 'foobar');
+
+		$this->assertEquals('AC123', $payload->iss);
+		$this->assertEquals('AC123', $payload->account_sid);
+		$this->assertEquals('WS456', $payload->channel);
+		$this->assertEquals('WS456', $payload->workspace_sid);
+		$this->assertEquals('v1', $payload->version);
+
+		$policies = $payload->policies;
+		$this->assertEquals(3, count($policies));
+
+		$this->assertEquals('https://event-bridge.twilio.com/v1/wschannels/AC123/WS456', $policies[0]->url);
+		$this->assertEquals('GET', $policies[0]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[0]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[0]);
+		$this->assertEquals(true, $policies[0]->allow);
+
+		$this->assertEquals('https://event-bridge.twilio.com/v1/wschannels/AC123/WS456', $policies[1]->url);
+		$this->assertEquals('POST', $policies[1]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[1]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[1]);
+		$this->assertEquals(true, $policies[1]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456', $policies[2]->url);
+		$this->assertEquals('GET', $policies[2]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[2]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[2]);
+		$this->assertEquals(true, $policies[2]->allow);
+	}
+
+	public function testWorkspaceFetchAll()
+	{
+		$workspaceCapability = new Services_Twilio_TaskRouter_Workspace_Capability('AC123', 'foobar', 'WS456');
+		$workspaceCapability->allowFetchSubresources();
+		$token = $workspaceCapability->generateToken();
+		$payload = JWT::decode($token, 'foobar');
+
+		$this->assertEquals('AC123', $payload->iss);
+		$this->assertEquals('AC123', $payload->account_sid);
+		$this->assertEquals('WS456', $payload->channel);
+		$this->assertEquals('WS456', $payload->workspace_sid);
+		$this->assertEquals('v1', $payload->version);
+
+		$policies = $payload->policies;
+		$this->assertEquals(4, count($policies));
+
+		$this->assertEquals('https://event-bridge.twilio.com/v1/wschannels/AC123/WS456', $policies[0]->url);
+		$this->assertEquals('GET', $policies[0]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[0]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[0]);
+		$this->assertEquals(true, $policies[0]->allow);
+
+		$this->assertEquals('https://event-bridge.twilio.com/v1/wschannels/AC123/WS456', $policies[1]->url);
+		$this->assertEquals('POST', $policies[1]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[1]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[1]);
+		$this->assertEquals(true, $policies[1]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456', $policies[2]->url);
+		$this->assertEquals('GET', $policies[2]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[2]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[2]);
+		$this->assertEquals(true, $policies[2]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/**', $policies[3]->url);
+		$this->assertEquals('GET', $policies[3]->method);
+		$this->assertEquals(new stdClass(), $policies[3]->query_filter);
+		$this->assertEquals(new stdClass(), $policies[3]->post_filter);
+		$this->assertEquals(true, $policies[3]->allow);
+	}
+
+	public function testDefaultTaskQueue()
+	{
+		$taskQueueCapability = new Services_Twilio_TaskRouter_TaskQueue_Capability('AC123', 'foobar', 'WS456', 'WQ789');
+		$token = $taskQueueCapability->generateToken();
+		$payload = JWT::decode($token, 'foobar');
+
+		$this->assertEquals('AC123', $payload->iss);
+		$this->assertEquals('AC123', $payload->account_sid);
+		$this->assertEquals('WQ789', $payload->channel);
+		$this->assertEquals('WS456', $payload->workspace_sid);
+		$this->assertEquals('WQ789', $payload->taskqueue_sid);
+		$this->assertEquals('v1', $payload->version);
+
+		$policies = $payload->policies;
+		$this->assertEquals(3, count($policies));
+
+		$this->assertEquals('https://event-bridge.twilio.com/v1/wschannels/AC123/WQ789', $policies[0]->url);
+		$this->assertEquals('GET', $policies[0]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[0]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[0]);
+		$this->assertEquals(true, $policies[0]->allow);
+
+		$this->assertEquals('https://event-bridge.twilio.com/v1/wschannels/AC123/WQ789', $policies[1]->url);
+		$this->assertEquals('POST', $policies[1]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[1]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[1]);
+		$this->assertEquals(true, $policies[1]->allow);
+
+		$this->assertEquals('https://taskrouter.twilio.com/v1/Workspaces/WS456/TaskQueues/WQ789', $policies[2]->url);
+		$this->assertEquals('GET', $policies[2]->method);
+		$this->assertObjectNotHasAttribute('query_filter', $policies[2]);
+		$this->assertObjectNotHasAttribute('post_filter', $policies[2]);
+		$this->assertEquals(true, $policies[2]->allow);
+	}
+}


### PR DESCRIPTION
- Allow fetching Reservations under a Worker by default
- Allow updating Reservations under a Worker