### PR TITLE
Twilio TaskRouter Capability autoload

### DIFF
--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -15,13 +15,13 @@ function Services_Twilio_autoload($className)
         && substr($className, 0, 23) != 'Pricing_Services_Twilio') {
         return false;
     }
-	if(substr($className, 0, 26) == 'Services_Twilio_TaskRouter') {
-		$file = "/Twilio/CapabilityTaskRouter";
-	}else {
-		$file = str_replace('_', '/', $className);
-		$file = str_replace('Services/', '', $file);
-	}
-	return include dirname(__FILE__) . "/$file.php";
+    if(substr($className, 0, 26) == 'Services_Twilio_TaskRouter') {
+        $file = "/Twilio/CapabilityTaskRouter";
+    }else {
+        $file = str_replace('_', '/', $className);
+        $file = str_replace('Services/', '', $file);
+    }
+    return include dirname(__FILE__) . "/$file.php";
 }
 
 spl_autoload_register('Services_Twilio_autoload');

--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -15,8 +15,8 @@ function Services_Twilio_autoload($className)
         && substr($className, 0, 23) != 'Pricing_Services_Twilio') {
         return false;
     }
-	$file = str_replace('_', '/', $className);
-	$file = str_replace('Services/', '', $file);
+    $file = str_replace('_', '/', $className);
+    $file = str_replace('Services/', '', $file);
     return include dirname(__FILE__) . "/$file.php";
 }
 

--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -455,9 +455,9 @@ class TaskRouter_Services_Twilio extends Base_Services_Twilio
     }
 
     protected function _getBaseUri()
-	{
-		return 'https://taskrouter.twilio.com';
-	}
+    {
+        return 'https://taskrouter.twilio.com';
+    }
 }
 
 /**

--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -15,15 +15,8 @@ function Services_Twilio_autoload($className)
         && substr($className, 0, 23) != 'Pricing_Services_Twilio') {
         return false;
     }
-    if(substr($className, 0, 37) == 'Services_Twilio_TaskRouter_Capability' ||
-        substr($className, 0, 45) == 'Services_Twilio_TaskRouter_Worker_Capability' ||
-        substr($className, 0, 48) == 'Services_Twilio_TaskRouter_TaskQueue_Capability' ||
-        substr($className, 0, 48) == 'Services_Twilio_TaskRouter_Workspace_Capability') {
-        $file = "/Twilio/CapabilityTaskRouter";
-    }else {
-        $file = str_replace('_', '/', $className);
-        $file = str_replace('Services/', '', $file);
-    }
+	$file = str_replace('_', '/', $className);
+	$file = str_replace('Services/', '', $file);
     return include dirname(__FILE__) . "/$file.php";
 }
 

--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -15,7 +15,10 @@ function Services_Twilio_autoload($className)
         && substr($className, 0, 23) != 'Pricing_Services_Twilio') {
         return false;
     }
-    if(substr($className, 0, 26) == 'Services_Twilio_TaskRouter') {
+    if(substr($className, 0, 37) == 'Services_Twilio_TaskRouter_Capability' ||
+        substr($className, 0, 45) == 'Services_Twilio_TaskRouter_Worker_Capability' ||
+        substr($className, 0, 48) == 'Services_Twilio_TaskRouter_TaskQueue_Capability' ||
+        substr($className, 0, 48) == 'Services_Twilio_TaskRouter_Workspace_Capability') {
         $file = "/Twilio/CapabilityTaskRouter";
     }else {
         $file = str_replace('_', '/', $className);

--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -9,7 +9,7 @@
 function Services_Twilio_autoload($className)
 {
     if (substr($className, 0, 15) != 'Services_Twilio'
-        && substr($className, 0, 26) != 'Services_Twilio_TaskRouter'
+        && substr($className, 0, 26) != 'TaskRouter_Services_Twilio'
         && substr($className, 0, 23) != 'Lookups_Services_Twilio'
         && substr($className, 0, 23) != 'Monitor_Services_Twilio'
         && substr($className, 0, 23) != 'Pricing_Services_Twilio') {

--- a/Services/Twilio.php
+++ b/Services/Twilio.php
@@ -9,15 +9,19 @@
 function Services_Twilio_autoload($className)
 {
     if (substr($className, 0, 15) != 'Services_Twilio'
-        && substr($className, 0, 26) != 'TaskRouter_Services_Twilio'
+        && substr($className, 0, 26) != 'Services_Twilio_TaskRouter'
         && substr($className, 0, 23) != 'Lookups_Services_Twilio'
         && substr($className, 0, 23) != 'Monitor_Services_Twilio'
         && substr($className, 0, 23) != 'Pricing_Services_Twilio') {
         return false;
     }
-    $file = str_replace('_', '/', $className);
-    $file = str_replace('Services/', '', $file);
-    return include dirname(__FILE__) . "/$file.php";
+	if(substr($className, 0, 26) == 'Services_Twilio_TaskRouter') {
+		$file = "/Twilio/CapabilityTaskRouter";
+	}else {
+		$file = str_replace('_', '/', $className);
+		$file = str_replace('Services/', '', $file);
+	}
+	return include dirname(__FILE__) . "/$file.php";
 }
 
 spl_autoload_register('Services_Twilio_autoload');
@@ -451,9 +455,9 @@ class TaskRouter_Services_Twilio extends Base_Services_Twilio
     }
 
     protected function _getBaseUri()
-    {
-        return 'https://taskrouter.twilio.com';
-    }
+	{
+		return 'https://taskrouter.twilio.com';
+	}
 }
 
 /**

--- a/Services/Twilio/TaskRouter/Capability.php
+++ b/Services/Twilio/TaskRouter/Capability.php
@@ -1,5 +1,4 @@
 <?php
-include_once '../CapabilityAPI.php';
 
 /**
  * Twilio TaskRouter Capability assigner
@@ -9,7 +8,7 @@ include_once '../CapabilityAPI.php';
  * @author Justin Witz <justin.witz@twilio.com>
  * @license  http://creativecommons.org/licenses/MIT/ MIT
  */
-class Services_Twilio_TaskRouter_Capability extends Services_Twilio_API_Capability
+class Services_Twilio_TaskRouter_Capability extends Services_Twilio_TaskRouter_CapabilityAPI
 {
 	protected $baseUrl = 'https://taskrouter.twilio.com/v1';
 	protected $baseWsUrl = 'https://event-bridge.twilio.com/v1/wschannels';

--- a/Services/Twilio/TaskRouter/Capability.php
+++ b/Services/Twilio/TaskRouter/Capability.php
@@ -1,5 +1,5 @@
 <?php
-include_once 'CapabilityAPI.php';
+include_once '../CapabilityAPI.php';
 
 /**
  * Twilio TaskRouter Capability assigner
@@ -166,94 +166,5 @@ class Services_Twilio_TaskRouter_Capability extends Services_Twilio_API_Capabili
 		}
 
 		return parent::generateToken($ttl, $taskRouterAttributes);
-	}
-}
-
-
-/**
- * Twilio TaskRouter Worker Capability assigner
- *
- * @category Services
- * @package  Services_Twilio
- * @author Justin Witz <justin.witz@twilio.com>
- * @license  http://creativecommons.org/licenses/MIT/ MIT
- */
-class Services_Twilio_TaskRouter_Worker_Capability extends Services_Twilio_TaskRouter_Capability
-{
-	private $tasksUrl;
-	private $workerReservationsUrl;
-	private $activityUrl;
-
-	public function __construct($accountSid, $authToken, $workspaceSid, $workerSid, $overrideBaseUrl = null, $overrideBaseWSUrl = null)
-	{
-		parent::__construct($accountSid, $authToken, $workspaceSid, $workerSid, null, $overrideBaseUrl, $overrideBaseWSUrl);
-
-		$this->tasksUrl = $this->baseUrl.'/Tasks/**';
-		$this->activityUrl = $this->baseUrl.'/Activities';
-		$this->workerReservationsUrl = $this->resourceUrl.'/Reservations/**';
-
-		//add permissions to fetch the list of activities, tasks, and worker reservations
-		$this->allow($this->activityUrl, "GET", null, null);
-		$this->allow($this->tasksUrl, "GET", null, null);
-		$this->allow($this->workerReservationsUrl, "GET", null, null);
-	}
-
-	protected function setupResource() {
-		$this->resourceUrl = $this->baseUrl.'/Workers/'.$this->channelId;
-	}
-
-	public function allowActivityUpdates() {
-		$method = 'POST';
-		$queryFilter = array();
-		$postFilter = array("ActivitySid" => $this->required);
-		$this->allow($this->resourceUrl, $method, $queryFilter, $postFilter);
-	}
-
-	public function allowReservationUpdates() {
-		$method = 'POST';
-		$queryFilter = array();
-		$postFilter = array();
-		$this->allow($this->tasksUrl, $method, $queryFilter, $postFilter);
-		$this->allow($this->workerReservationsUrl, $method, $queryFilter, $postFilter);
-	}
-}
-
-/**
- * Twilio TaskRouter TaskQueue Capability assigner
- *
- * @category Services
- * @package  Services_Twilio
- * @author Justin Witz <justin.witz@twilio.com>
- * @license  http://creativecommons.org/licenses/MIT/ MIT
- */
-class Services_Twilio_TaskRouter_TaskQueue_Capability extends Services_Twilio_TaskRouter_Capability
-{
-	public function __construct($accountSid, $authToken, $workspaceSid, $taskQueueSid, $overrideBaseUrl = null, $overrideBaseWSUrl = null)
-	{
-		parent::__construct($accountSid, $authToken, $workspaceSid, $taskQueueSid, null, $overrideBaseUrl, $overrideBaseWSUrl);
-	}
-
-	protected function setupResource() {
-		$this->resourceUrl = $this->baseUrl.'/TaskQueues/'.$this->channelId;
-	}
-}
-
-/**
- * Twilio TaskRouter Workspace Capability assigner
- *
- * @category Services
- * @package  Services_Twilio
- * @author Justin Witz <justin.witz@twilio.com>
- * @license  http://creativecommons.org/licenses/MIT/ MIT
- */
-class Services_Twilio_TaskRouter_Workspace_Capability extends Services_Twilio_TaskRouter_Capability
-{
-	public function __construct($accountSid, $authToken, $workspaceSid, $overrideBaseUrl = null, $overrideBaseWSUrl = null)
-	{
-		parent::__construct($accountSid, $authToken, $workspaceSid, $workspaceSid, null, $overrideBaseUrl, $overrideBaseWSUrl);
-	}
-
-	protected function setupResource() {
-		$this->resourceUrl = $this->baseUrl;
 	}
 }

--- a/Services/Twilio/TaskRouter/CapabilityAPI.php
+++ b/Services/Twilio/TaskRouter/CapabilityAPI.php
@@ -1,5 +1,4 @@
 <?php
-include_once 'JWT.php';
 /**
  * Twilio API Capability Token generator
  *
@@ -8,7 +7,7 @@ include_once 'JWT.php';
  * @author Justin Witz <justin.witz@twilio.com>
  * @license  http://creativecommons.org/licenses/MIT/ MIT
  */
-class Services_Twilio_API_Capability
+class Services_Twilio_TaskRouter_CapabilityAPI
 {
 	protected $accountSid;
 	protected $authToken;

--- a/Services/Twilio/TaskRouter/TaskQueue/Capability.php
+++ b/Services/Twilio/TaskRouter/TaskQueue/Capability.php
@@ -1,5 +1,4 @@
 <?php
-include_once '../Capability.php';
 
 /**
  * Twilio TaskRouter TaskQueue Capability assigner

--- a/Services/Twilio/TaskRouter/TaskQueue/Capability.php
+++ b/Services/Twilio/TaskRouter/TaskQueue/Capability.php
@@ -1,0 +1,22 @@
+<?php
+include_once '../Capability.php';
+
+/**
+ * Twilio TaskRouter TaskQueue Capability assigner
+ *
+ * @category Services
+ * @package  Services_Twilio
+ * @author Justin Witz <justin.witz@twilio.com>
+ * @license  http://creativecommons.org/licenses/MIT/ MIT
+ */
+class Services_Twilio_TaskRouter_TaskQueue_Capability extends Services_Twilio_TaskRouter_Capability
+{
+	public function __construct($accountSid, $authToken, $workspaceSid, $taskQueueSid, $overrideBaseUrl = null, $overrideBaseWSUrl = null)
+	{
+		parent::__construct($accountSid, $authToken, $workspaceSid, $taskQueueSid, null, $overrideBaseUrl, $overrideBaseWSUrl);
+	}
+
+	protected function setupResource() {
+		$this->resourceUrl = $this->baseUrl.'/TaskQueues/'.$this->channelId;
+	}
+}

--- a/Services/Twilio/TaskRouter/Worker/Capability.php
+++ b/Services/Twilio/TaskRouter/Worker/Capability.php
@@ -1,0 +1,50 @@
+<?php
+require_once('../Capability.php');
+
+/**
+ * Twilio TaskRouter Worker Capability assigner
+ *
+ * @category Services
+ * @package  Services_Twilio
+ * @author Justin Witz <justin.witz@twilio.com>
+ * @license  http://creativecommons.org/licenses/MIT/ MIT
+ */
+class Services_Twilio_TaskRouter_Worker_Capability extends Services_Twilio_TaskRouter_Capability
+{
+	private $tasksUrl;
+	private $workerReservationsUrl;
+	private $activityUrl;
+
+	public function __construct($accountSid, $authToken, $workspaceSid, $workerSid, $overrideBaseUrl = null, $overrideBaseWSUrl = null)
+	{
+		parent::__construct($accountSid, $authToken, $workspaceSid, $workerSid, null, $overrideBaseUrl, $overrideBaseWSUrl);
+
+		$this->tasksUrl = $this->baseUrl.'/Tasks/**';
+		$this->activityUrl = $this->baseUrl.'/Activities';
+		$this->workerReservationsUrl = $this->resourceUrl.'/Reservations/**';
+
+		//add permissions to fetch the list of activities, tasks, and worker reservations
+		$this->allow($this->activityUrl, "GET", null, null);
+		$this->allow($this->tasksUrl, "GET", null, null);
+		$this->allow($this->workerReservationsUrl, "GET", null, null);
+	}
+
+	protected function setupResource() {
+		$this->resourceUrl = $this->baseUrl.'/Workers/'.$this->channelId;
+	}
+
+	public function allowActivityUpdates() {
+		$method = 'POST';
+		$queryFilter = array();
+		$postFilter = array("ActivitySid" => $this->required);
+		$this->allow($this->resourceUrl, $method, $queryFilter, $postFilter);
+	}
+
+	public function allowReservationUpdates() {
+		$method = 'POST';
+		$queryFilter = array();
+		$postFilter = array();
+		$this->allow($this->tasksUrl, $method, $queryFilter, $postFilter);
+		$this->allow($this->workerReservationsUrl, $method, $queryFilter, $postFilter);
+	}
+}

--- a/Services/Twilio/TaskRouter/Worker/Capability.php
+++ b/Services/Twilio/TaskRouter/Worker/Capability.php
@@ -1,5 +1,4 @@
 <?php
-require_once('../Capability.php');
 
 /**
  * Twilio TaskRouter Worker Capability assigner

--- a/Services/Twilio/TaskRouter/Workspace/Capability.php
+++ b/Services/Twilio/TaskRouter/Workspace/Capability.php
@@ -1,0 +1,22 @@
+<?php
+include_once '../Capability.php';
+
+/**
+ * Twilio TaskRouter Workspace Capability assigner
+ *
+ * @category Services
+ * @package  Services_Twilio
+ * @author Justin Witz <justin.witz@twilio.com>
+ * @license  http://creativecommons.org/licenses/MIT/ MIT
+ */
+class Services_Twilio_TaskRouter_Workspace_Capability extends Services_Twilio_TaskRouter_Capability
+{
+	public function __construct($accountSid, $authToken, $workspaceSid, $overrideBaseUrl = null, $overrideBaseWSUrl = null)
+	{
+		parent::__construct($accountSid, $authToken, $workspaceSid, $workspaceSid, null, $overrideBaseUrl, $overrideBaseWSUrl);
+	}
+
+	protected function setupResource() {
+		$this->resourceUrl = $this->baseUrl;
+	}
+}

--- a/Services/Twilio/TaskRouter/Workspace/Capability.php
+++ b/Services/Twilio/TaskRouter/Workspace/Capability.php
@@ -1,5 +1,4 @@
 <?php
-include_once '../Capability.php';
 
 /**
  * Twilio TaskRouter Workspace Capability assigner

--- a/tests/CapabilityTaskRouterTest.php
+++ b/tests/CapabilityTaskRouterTest.php
@@ -1,6 +1,9 @@
 <?php
 
-require_once 'Twilio/CapabilityTaskRouter.php';
+require_once 'Twilio/TaskRouter/Workspace/Capability.php';
+require_once 'Twilio/TaskRouter/Worker/Capability.php';
+require_once 'Twilio/TaskRouter/TaskQueue/Capability.php';
+require_once 'Twilio/TaskRouter/Capability.php';
 
 class CapabilityTaskRouter extends PHPUnit_Framework_TestCase {
 


### PR DESCRIPTION
We need to directly reference CapabilityTaskRouter since this not follow the pattern of matching file name to matching class name.