### PR TITLE
Fix namespace

### DIFF
--- a/Twilio/Twiml.php
+++ b/Twilio/Twiml.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Twilio\Twiml;
+namespace Twilio;
 use Twilio\Exceptions\TwimlException;
 
 /**


### PR DESCRIPTION
The file namespace is not correct, so it's not possible to use the class `new \Twilio\Twiml\Twiml()`