### PR TITLE
Encode parameter key

### DIFF
--- a/Twilio/Http/CurlClient.php
+++ b/Twilio/Http/CurlClient.php
@@ -134,10 +134,10 @@ class CurlClient implements Client {
         foreach ($params as $key => $value) {
             if (is_array($value)) {
                 foreach ($value as $item) {
-                    $parts[] = $key . '=' . urlencode((string)$item);
+                    $parts[] = urlencode((string)$key) . '=' . urlencode((string)$item);
                 }
             } else {
-                $parts[] = $key . '=' . urlencode((string)$value);
+                $parts[] = urlencode((string)$key) . '=' . urlencode((string)$value);
             }
         }
 

--- a/Twilio/Tests/Unit/Http/CurlClientTest.php
+++ b/Twilio/Tests/Unit/Http/CurlClientTest.php
@@ -114,6 +114,13 @@ class CurlClientTest extends UnitTest {
                     'a' => 'un$afe:// value!',
                 ),
                 'a=un%24afe%3A%2F%2F+value%21',
+            ),
+            array(
+                'Encoded Key',
+                array(
+                    'StartTime>' => '2012-06-14',
+                ),
+                'StartTime%3E=2012-06-14',
             )
         );
     }


### PR DESCRIPTION
Encode keys in the URL. Current version of the API supports parameter names with special characters. For example: 

* `StartTime>`
* `StartTime<`