### PR TITLE
next-gen: The namespace should be Twilio, not Twilio\Twiml.

### DIFF
--- a/Twilio/Twiml.php
+++ b/Twilio/Twiml.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Twilio\Twiml;
+namespace Twilio;
 use Twilio\Exceptions\TwimlException;
 
 /**


### PR DESCRIPTION
If it was Twilio\Twiml, the class would have to be instantiated with Twilio\Twiml\Twiml which does not work with the autoloader.