### PR TITLE
rawurlencode solution arguments before interpolation

### DIFF
--- a/Twilio/Rest/Api/V2010/Account/Address/DependentPhoneNumberList.php
+++ b/Twilio/Rest/Api/V2010/Account/Address/DependentPhoneNumberList.php
@@ -31,7 +31,7 @@ class DependentPhoneNumberList extends ListResource {
             'addressSid' => $addressSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Addresses/' . $addressSid . '/DependentPhoneNumbers.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Addresses/' . rawurlencode($addressSid) . '/DependentPhoneNumbers.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AddressContext.php
+++ b/Twilio/Rest/Api/V2010/Account/AddressContext.php
@@ -39,7 +39,7 @@ class AddressContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Addresses/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Addresses/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AddressList.php
+++ b/Twilio/Rest/Api/V2010/Account/AddressList.php
@@ -30,7 +30,7 @@ class AddressList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Addresses.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Addresses.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ApplicationContext.php
+++ b/Twilio/Rest/Api/V2010/Account/ApplicationContext.php
@@ -32,7 +32,7 @@ class ApplicationContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Applications/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Applications/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ApplicationList.php
+++ b/Twilio/Rest/Api/V2010/Account/ApplicationList.php
@@ -30,7 +30,7 @@ class ApplicationList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Applications.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Applications.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AuthorizedConnectAppContext.php
+++ b/Twilio/Rest/Api/V2010/Account/AuthorizedConnectAppContext.php
@@ -31,7 +31,7 @@ class AuthorizedConnectAppContext extends InstanceContext {
             'connectAppSid' => $connectAppSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/AuthorizedConnectApps/' . $connectAppSid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/AuthorizedConnectApps/' . rawurlencode($connectAppSid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AuthorizedConnectAppList.php
+++ b/Twilio/Rest/Api/V2010/Account/AuthorizedConnectAppList.php
@@ -29,7 +29,7 @@ class AuthorizedConnectAppList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/AuthorizedConnectApps.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/AuthorizedConnectApps.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/LocalList.php
+++ b/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/LocalList.php
@@ -33,7 +33,7 @@ class LocalList extends ListResource {
             'countryCode' => $countryCode,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/AvailablePhoneNumbers/' . $countryCode . '/Local.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/AvailablePhoneNumbers/' . rawurlencode($countryCode) . '/Local.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/MobileList.php
+++ b/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/MobileList.php
@@ -33,7 +33,7 @@ class MobileList extends ListResource {
             'countryCode' => $countryCode,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/AvailablePhoneNumbers/' . $countryCode . '/Mobile.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/AvailablePhoneNumbers/' . rawurlencode($countryCode) . '/Mobile.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/TollFreeList.php
+++ b/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/TollFreeList.php
@@ -33,7 +33,7 @@ class TollFreeList extends ListResource {
             'countryCode' => $countryCode,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/AvailablePhoneNumbers/' . $countryCode . '/TollFree.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/AvailablePhoneNumbers/' . rawurlencode($countryCode) . '/TollFree.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountryContext.php
+++ b/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountryContext.php
@@ -44,7 +44,7 @@ class AvailablePhoneNumberCountryContext extends InstanceContext {
             'countryCode' => $countryCode,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/AvailablePhoneNumbers/' . $countryCode . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/AvailablePhoneNumbers/' . rawurlencode($countryCode) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountryList.php
+++ b/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountryList.php
@@ -30,7 +30,7 @@ class AvailablePhoneNumberCountryList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/AvailablePhoneNumbers.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/AvailablePhoneNumbers.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Call/FeedbackContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Call/FeedbackContext.php
@@ -32,7 +32,7 @@ class FeedbackContext extends InstanceContext {
             'callSid' => $callSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls/' . $callSid . '/Feedback.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls/' . rawurlencode($callSid) . '/Feedback.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Call/FeedbackSummaryContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Call/FeedbackSummaryContext.php
@@ -31,7 +31,7 @@ class FeedbackSummaryContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls/FeedbackSummary/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls/FeedbackSummary/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Call/FeedbackSummaryList.php
+++ b/Twilio/Rest/Api/V2010/Account/Call/FeedbackSummaryList.php
@@ -31,7 +31,7 @@ class FeedbackSummaryList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls/FeedbackSummary.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls/FeedbackSummary.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Call/NotificationContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Call/NotificationContext.php
@@ -33,7 +33,7 @@ class NotificationContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls/' . $callSid . '/Notifications/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls/' . rawurlencode($callSid) . '/Notifications/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Call/NotificationList.php
+++ b/Twilio/Rest/Api/V2010/Account/Call/NotificationList.php
@@ -32,7 +32,7 @@ class NotificationList extends ListResource {
             'callSid' => $callSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls/' . $callSid . '/Notifications.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls/' . rawurlencode($callSid) . '/Notifications.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Call/RecordingContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Call/RecordingContext.php
@@ -33,7 +33,7 @@ class RecordingContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls/' . $callSid . '/Recordings/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls/' . rawurlencode($callSid) . '/Recordings/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Call/RecordingList.php
+++ b/Twilio/Rest/Api/V2010/Account/Call/RecordingList.php
@@ -32,7 +32,7 @@ class RecordingList extends ListResource {
             'callSid' => $callSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls/' . $callSid . '/Recordings.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls/' . rawurlencode($callSid) . '/Recordings.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/CallContext.php
+++ b/Twilio/Rest/Api/V2010/Account/CallContext.php
@@ -48,7 +48,7 @@ class CallContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/CallList.php
+++ b/Twilio/Rest/Api/V2010/Account/CallList.php
@@ -39,7 +39,7 @@ class CallList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Calls.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Calls.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Conference/ParticipantContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Conference/ParticipantContext.php
@@ -34,7 +34,7 @@ class ParticipantContext extends InstanceContext {
             'callSid' => $callSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Conferences/' . $conferenceSid . '/Participants/' . $callSid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Conferences/' . rawurlencode($conferenceSid) . '/Participants/' . rawurlencode($callSid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Conference/ParticipantList.php
+++ b/Twilio/Rest/Api/V2010/Account/Conference/ParticipantList.php
@@ -33,7 +33,7 @@ class ParticipantList extends ListResource {
             'conferenceSid' => $conferenceSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Conferences/' . $conferenceSid . '/Participants.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Conferences/' . rawurlencode($conferenceSid) . '/Participants.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ConferenceContext.php
+++ b/Twilio/Rest/Api/V2010/Account/ConferenceContext.php
@@ -39,7 +39,7 @@ class ConferenceContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Conferences/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Conferences/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ConferenceList.php
+++ b/Twilio/Rest/Api/V2010/Account/ConferenceList.php
@@ -30,7 +30,7 @@ class ConferenceList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Conferences.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Conferences.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ConnectAppContext.php
+++ b/Twilio/Rest/Api/V2010/Account/ConnectAppContext.php
@@ -32,7 +32,7 @@ class ConnectAppContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/ConnectApps/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/ConnectApps/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ConnectAppList.php
+++ b/Twilio/Rest/Api/V2010/Account/ConnectAppList.php
@@ -29,7 +29,7 @@ class ConnectAppList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/ConnectApps.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/ConnectApps.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/LocalList.php
+++ b/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/LocalList.php
@@ -31,7 +31,7 @@ class LocalList extends ListResource {
             'ownerAccountSid' => $ownerAccountSid,
         );
         
-        $this->uri = '/Accounts/' . $ownerAccountSid . '/IncomingPhoneNumbers/Local.json';
+        $this->uri = '/Accounts/' . rawurlencode($ownerAccountSid) . '/IncomingPhoneNumbers/Local.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/MobileList.php
+++ b/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/MobileList.php
@@ -31,7 +31,7 @@ class MobileList extends ListResource {
             'ownerAccountSid' => $ownerAccountSid,
         );
         
-        $this->uri = '/Accounts/' . $ownerAccountSid . '/IncomingPhoneNumbers/Mobile.json';
+        $this->uri = '/Accounts/' . rawurlencode($ownerAccountSid) . '/IncomingPhoneNumbers/Mobile.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/TollFreeList.php
+++ b/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/TollFreeList.php
@@ -31,7 +31,7 @@ class TollFreeList extends ListResource {
             'ownerAccountSid' => $ownerAccountSid,
         );
         
-        $this->uri = '/Accounts/' . $ownerAccountSid . '/IncomingPhoneNumbers/TollFree.json';
+        $this->uri = '/Accounts/' . rawurlencode($ownerAccountSid) . '/IncomingPhoneNumbers/TollFree.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumberContext.php
+++ b/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumberContext.php
@@ -32,7 +32,7 @@ class IncomingPhoneNumberContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $ownerAccountSid . '/IncomingPhoneNumbers/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($ownerAccountSid) . '/IncomingPhoneNumbers/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumberList.php
+++ b/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumberList.php
@@ -44,7 +44,7 @@ class IncomingPhoneNumberList extends ListResource {
             'ownerAccountSid' => $ownerAccountSid,
         );
         
-        $this->uri = '/Accounts/' . $ownerAccountSid . '/IncomingPhoneNumbers.json';
+        $this->uri = '/Accounts/' . rawurlencode($ownerAccountSid) . '/IncomingPhoneNumbers.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/KeyContext.php
+++ b/Twilio/Rest/Api/V2010/Account/KeyContext.php
@@ -32,7 +32,7 @@ class KeyContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Keys/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Keys/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/KeyList.php
+++ b/Twilio/Rest/Api/V2010/Account/KeyList.php
@@ -30,7 +30,7 @@ class KeyList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Keys.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Keys.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Message/FeedbackList.php
+++ b/Twilio/Rest/Api/V2010/Account/Message/FeedbackList.php
@@ -32,7 +32,7 @@ class FeedbackList extends ListResource {
             'messageSid' => $messageSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Messages/' . $messageSid . '/Feedback.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Messages/' . rawurlencode($messageSid) . '/Feedback.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Message/MediaContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Message/MediaContext.php
@@ -33,7 +33,7 @@ class MediaContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Messages/' . $messageSid . '/Media/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Messages/' . rawurlencode($messageSid) . '/Media/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Message/MediaList.php
+++ b/Twilio/Rest/Api/V2010/Account/Message/MediaList.php
@@ -32,7 +32,7 @@ class MediaList extends ListResource {
             'messageSid' => $messageSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Messages/' . $messageSid . '/Media.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Messages/' . rawurlencode($messageSid) . '/Media.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/MessageContext.php
+++ b/Twilio/Rest/Api/V2010/Account/MessageContext.php
@@ -43,7 +43,7 @@ class MessageContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Messages/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Messages/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/MessageList.php
+++ b/Twilio/Rest/Api/V2010/Account/MessageList.php
@@ -30,7 +30,7 @@ class MessageList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Messages.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Messages.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/NewKeyList.php
+++ b/Twilio/Rest/Api/V2010/Account/NewKeyList.php
@@ -31,7 +31,7 @@ class NewKeyList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Keys.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Keys.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/NewSigningKeyList.php
+++ b/Twilio/Rest/Api/V2010/Account/NewSigningKeyList.php
@@ -31,7 +31,7 @@ class NewSigningKeyList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SigningKeys.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SigningKeys.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/NotificationContext.php
+++ b/Twilio/Rest/Api/V2010/Account/NotificationContext.php
@@ -31,7 +31,7 @@ class NotificationContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Notifications/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Notifications/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/NotificationList.php
+++ b/Twilio/Rest/Api/V2010/Account/NotificationList.php
@@ -30,7 +30,7 @@ class NotificationList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Notifications.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Notifications.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/OutgoingCallerIdContext.php
+++ b/Twilio/Rest/Api/V2010/Account/OutgoingCallerIdContext.php
@@ -32,7 +32,7 @@ class OutgoingCallerIdContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/OutgoingCallerIds/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/OutgoingCallerIds/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/OutgoingCallerIdList.php
+++ b/Twilio/Rest/Api/V2010/Account/OutgoingCallerIdList.php
@@ -30,7 +30,7 @@ class OutgoingCallerIdList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/OutgoingCallerIds.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/OutgoingCallerIds.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Queue/MemberContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Queue/MemberContext.php
@@ -33,7 +33,7 @@ class MemberContext extends InstanceContext {
             'callSid' => $callSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Queues/' . $queueSid . '/Members/' . $callSid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Queues/' . rawurlencode($queueSid) . '/Members/' . rawurlencode($callSid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Queue/MemberList.php
+++ b/Twilio/Rest/Api/V2010/Account/Queue/MemberList.php
@@ -31,7 +31,7 @@ class MemberList extends ListResource {
             'queueSid' => $queueSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Queues/' . $queueSid . '/Members.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Queues/' . rawurlencode($queueSid) . '/Members.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/QueueContext.php
+++ b/Twilio/Rest/Api/V2010/Account/QueueContext.php
@@ -40,7 +40,7 @@ class QueueContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Queues/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Queues/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/QueueList.php
+++ b/Twilio/Rest/Api/V2010/Account/QueueList.php
@@ -30,7 +30,7 @@ class QueueList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Queues.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Queues.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Recording/TranscriptionContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Recording/TranscriptionContext.php
@@ -33,7 +33,7 @@ class TranscriptionContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Recordings/' . $recordingSid . '/Transcriptions/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Recordings/' . rawurlencode($recordingSid) . '/Transcriptions/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Recording/TranscriptionList.php
+++ b/Twilio/Rest/Api/V2010/Account/Recording/TranscriptionList.php
@@ -31,7 +31,7 @@ class TranscriptionList extends ListResource {
             'recordingSid' => $recordingSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Recordings/' . $recordingSid . '/Transcriptions.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Recordings/' . rawurlencode($recordingSid) . '/Transcriptions.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/RecordingContext.php
+++ b/Twilio/Rest/Api/V2010/Account/RecordingContext.php
@@ -39,7 +39,7 @@ class RecordingContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Recordings/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Recordings/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/RecordingList.php
+++ b/Twilio/Rest/Api/V2010/Account/RecordingList.php
@@ -30,7 +30,7 @@ class RecordingList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Recordings.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Recordings.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/SandboxContext.php
+++ b/Twilio/Rest/Api/V2010/Account/SandboxContext.php
@@ -30,7 +30,7 @@ class SandboxContext extends InstanceContext {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Sandbox.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Sandbox.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ShortCodeContext.php
+++ b/Twilio/Rest/Api/V2010/Account/ShortCodeContext.php
@@ -32,7 +32,7 @@ class ShortCodeContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SMS/ShortCodes/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SMS/ShortCodes/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ShortCodeList.php
+++ b/Twilio/Rest/Api/V2010/Account/ShortCodeList.php
@@ -30,7 +30,7 @@ class ShortCodeList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SMS/ShortCodes.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SMS/ShortCodes.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/SigningKeyContext.php
+++ b/Twilio/Rest/Api/V2010/Account/SigningKeyContext.php
@@ -32,7 +32,7 @@ class SigningKeyContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SigningKeys/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SigningKeys/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/SigningKeyList.php
+++ b/Twilio/Rest/Api/V2010/Account/SigningKeyList.php
@@ -30,7 +30,7 @@ class SigningKeyList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SigningKeys.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SigningKeys.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/CredentialList/CredentialContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/CredentialList/CredentialContext.php
@@ -33,7 +33,7 @@ class CredentialContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/CredentialLists/' . $credentialListSid . '/Credentials/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/CredentialLists/' . rawurlencode($credentialListSid) . '/Credentials/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/CredentialList/CredentialList.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/CredentialList/CredentialList.php
@@ -31,7 +31,7 @@ class CredentialList extends ListResource {
             'credentialListSid' => $credentialListSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/CredentialLists/' . $credentialListSid . '/Credentials.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/CredentialLists/' . rawurlencode($credentialListSid) . '/Credentials.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/CredentialListContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/CredentialListContext.php
@@ -39,7 +39,7 @@ class CredentialListContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/CredentialLists/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/CredentialLists/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/CredentialListList.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/CredentialListList.php
@@ -30,7 +30,7 @@ class CredentialListList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/CredentialLists.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/CredentialLists.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/Domain/CredentialListMappingContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/Domain/CredentialListMappingContext.php
@@ -33,7 +33,7 @@ class CredentialListMappingContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/Domains/' . $domainSid . '/CredentialListMappings/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/Domains/' . rawurlencode($domainSid) . '/CredentialListMappings/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/Domain/CredentialListMappingList.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/Domain/CredentialListMappingList.php
@@ -31,7 +31,7 @@ class CredentialListMappingList extends ListResource {
             'domainSid' => $domainSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/Domains/' . $domainSid . '/CredentialListMappings.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/Domains/' . rawurlencode($domainSid) . '/CredentialListMappings.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/Domain/IpAccessControlListMappingContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/Domain/IpAccessControlListMappingContext.php
@@ -33,7 +33,7 @@ class IpAccessControlListMappingContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/Domains/' . $domainSid . '/IpAccessControlListMappings/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/Domains/' . rawurlencode($domainSid) . '/IpAccessControlListMappings/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/Domain/IpAccessControlListMappingList.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/Domain/IpAccessControlListMappingList.php
@@ -31,7 +31,7 @@ class IpAccessControlListMappingList extends ListResource {
             'domainSid' => $domainSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/Domains/' . $domainSid . '/IpAccessControlListMappings.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/Domains/' . rawurlencode($domainSid) . '/IpAccessControlListMappings.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/DomainContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/DomainContext.php
@@ -44,7 +44,7 @@ class DomainContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/Domains/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/Domains/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/DomainList.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/DomainList.php
@@ -31,7 +31,7 @@ class DomainList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/Domains.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/Domains.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlList/IpAddressContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlList/IpAddressContext.php
@@ -34,7 +34,7 @@ class IpAddressContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/IpAccessControlLists/' . $ipAccessControlListSid . '/IpAddresses/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/IpAccessControlLists/' . rawurlencode($ipAccessControlListSid) . '/IpAddresses/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlList/IpAddressList.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlList/IpAddressList.php
@@ -31,7 +31,7 @@ class IpAddressList extends ListResource {
             'ipAccessControlListSid' => $ipAccessControlListSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/IpAccessControlLists/' . $ipAccessControlListSid . '/IpAddresses.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/IpAccessControlLists/' . rawurlencode($ipAccessControlListSid) . '/IpAddresses.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlListContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlListContext.php
@@ -39,7 +39,7 @@ class IpAccessControlListContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/IpAccessControlLists/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/IpAccessControlLists/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlListList.php
+++ b/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlListList.php
@@ -30,7 +30,7 @@ class IpAccessControlListList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/SIP/IpAccessControlLists.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/SIP/IpAccessControlLists.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/TokenList.php
+++ b/Twilio/Rest/Api/V2010/Account/TokenList.php
@@ -30,7 +30,7 @@ class TokenList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Tokens.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Tokens.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/TranscriptionContext.php
+++ b/Twilio/Rest/Api/V2010/Account/TranscriptionContext.php
@@ -31,7 +31,7 @@ class TranscriptionContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Transcriptions/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Transcriptions/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/TranscriptionList.php
+++ b/Twilio/Rest/Api/V2010/Account/TranscriptionList.php
@@ -29,7 +29,7 @@ class TranscriptionList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Transcriptions.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Transcriptions.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/Record/AllTimeList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/Record/AllTimeList.php
@@ -31,7 +31,7 @@ class AllTimeList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records/AllTime.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records/AllTime.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/Record/DailyList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/Record/DailyList.php
@@ -31,7 +31,7 @@ class DailyList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records/Daily.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records/Daily.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/Record/LastMonthList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/Record/LastMonthList.php
@@ -31,7 +31,7 @@ class LastMonthList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records/LastMonth.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records/LastMonth.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/Record/MonthlyList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/Record/MonthlyList.php
@@ -31,7 +31,7 @@ class MonthlyList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records/Monthly.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records/Monthly.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/Record/ThisMonthList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/Record/ThisMonthList.php
@@ -31,7 +31,7 @@ class ThisMonthList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records/ThisMonth.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records/ThisMonth.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/Record/TodayList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/Record/TodayList.php
@@ -31,7 +31,7 @@ class TodayList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records/Today.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records/Today.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/Record/YearlyList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/Record/YearlyList.php
@@ -31,7 +31,7 @@ class YearlyList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records/Yearly.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records/Yearly.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/Record/YesterdayList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/Record/YesterdayList.php
@@ -31,7 +31,7 @@ class YesterdayList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records/Yesterday.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records/Yesterday.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/RecordList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/RecordList.php
@@ -59,7 +59,7 @@ class RecordList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Records.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Records.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/TriggerContext.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/TriggerContext.php
@@ -32,7 +32,7 @@ class TriggerContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Triggers/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Triggers/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/Usage/TriggerList.php
+++ b/Twilio/Rest/Api/V2010/Account/Usage/TriggerList.php
@@ -31,7 +31,7 @@ class TriggerList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/Usage/Triggers.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/Usage/Triggers.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/Account/ValidationRequestList.php
+++ b/Twilio/Rest/Api/V2010/Account/ValidationRequestList.php
@@ -30,7 +30,7 @@ class ValidationRequestList extends ListResource {
             'accountSid' => $accountSid,
         );
         
-        $this->uri = '/Accounts/' . $accountSid . '/OutgoingCallerIds.json';
+        $this->uri = '/Accounts/' . rawurlencode($accountSid) . '/OutgoingCallerIds.json';
     }
 
     /**

--- a/Twilio/Rest/Api/V2010/AccountContext.php
+++ b/Twilio/Rest/Api/V2010/AccountContext.php
@@ -124,7 +124,7 @@ class AccountContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Accounts/' . $sid . '.json';
+        $this->uri = '/Accounts/' . rawurlencode($sid) . '.json';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/CredentialContext.php
+++ b/Twilio/Rest/IpMessaging/V1/CredentialContext.php
@@ -30,7 +30,7 @@ class CredentialContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Credentials/' . $sid . '';
+        $this->uri = '/Credentials/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/Channel/MemberContext.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/Channel/MemberContext.php
@@ -33,7 +33,7 @@ class MemberContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Channels/' . $channelSid . '/Members/' . $sid . '';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Channels/' . rawurlencode($channelSid) . '/Members/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/Channel/MemberList.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/Channel/MemberList.php
@@ -32,7 +32,7 @@ class MemberList extends ListResource {
             'channelSid' => $channelSid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Channels/' . $channelSid . '/Members';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Channels/' . rawurlencode($channelSid) . '/Members';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/Channel/MessageContext.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/Channel/MessageContext.php
@@ -34,7 +34,7 @@ class MessageContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Channels/' . $channelSid . '/Messages/' . $sid . '';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Channels/' . rawurlencode($channelSid) . '/Messages/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/Channel/MessageList.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/Channel/MessageList.php
@@ -32,7 +32,7 @@ class MessageList extends ListResource {
             'channelSid' => $channelSid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Channels/' . $channelSid . '/Messages';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Channels/' . rawurlencode($channelSid) . '/Messages';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/ChannelContext.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/ChannelContext.php
@@ -44,7 +44,7 @@ class ChannelContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Channels/' . $sid . '';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Channels/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/ChannelList.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/ChannelList.php
@@ -30,7 +30,7 @@ class ChannelList extends ListResource {
             'serviceSid' => $serviceSid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Channels';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Channels';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/RoleContext.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/RoleContext.php
@@ -31,7 +31,7 @@ class RoleContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Roles/' . $sid . '';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Roles/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/RoleList.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/RoleList.php
@@ -29,7 +29,7 @@ class RoleList extends ListResource {
             'serviceSid' => $serviceSid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Roles';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Roles';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/UserContext.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/UserContext.php
@@ -32,7 +32,7 @@ class UserContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Users/' . $sid . '';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Users/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/Service/UserList.php
+++ b/Twilio/Rest/IpMessaging/V1/Service/UserList.php
@@ -29,7 +29,7 @@ class UserList extends ListResource {
             'serviceSid' => $serviceSid,
         );
         
-        $this->uri = '/Services/' . $serviceSid . '/Users';
+        $this->uri = '/Services/' . rawurlencode($serviceSid) . '/Users';
     }
 
     /**

--- a/Twilio/Rest/IpMessaging/V1/ServiceContext.php
+++ b/Twilio/Rest/IpMessaging/V1/ServiceContext.php
@@ -46,7 +46,7 @@ class ServiceContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Services/' . $sid . '';
+        $this->uri = '/Services/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Lookups/V1/PhoneNumberContext.php
+++ b/Twilio/Rest/Lookups/V1/PhoneNumberContext.php
@@ -31,7 +31,7 @@ class PhoneNumberContext extends InstanceContext {
             'phoneNumber' => $phoneNumber,
         );
         
-        $this->uri = '/PhoneNumbers/' . $phoneNumber . '';
+        $this->uri = '/PhoneNumbers/' . rawurlencode($phoneNumber) . '';
     }
 
     /**

--- a/Twilio/Rest/Monitor/V1/AlertContext.php
+++ b/Twilio/Rest/Monitor/V1/AlertContext.php
@@ -29,7 +29,7 @@ class AlertContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Alerts/' . $sid . '';
+        $this->uri = '/Alerts/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Monitor/V1/EventContext.php
+++ b/Twilio/Rest/Monitor/V1/EventContext.php
@@ -29,7 +29,7 @@ class EventContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Events/' . $sid . '';
+        $this->uri = '/Events/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Pricing/V1/Messaging/CountryContext.php
+++ b/Twilio/Rest/Pricing/V1/Messaging/CountryContext.php
@@ -29,7 +29,7 @@ class CountryContext extends InstanceContext {
             'isoCountry' => $isoCountry,
         );
         
-        $this->uri = '/Messaging/Countries/' . $isoCountry . '';
+        $this->uri = '/Messaging/Countries/' . rawurlencode($isoCountry) . '';
     }
 
     /**

--- a/Twilio/Rest/Pricing/V1/PhoneNumber/CountryContext.php
+++ b/Twilio/Rest/Pricing/V1/PhoneNumber/CountryContext.php
@@ -29,7 +29,7 @@ class CountryContext extends InstanceContext {
             'isoCountry' => $isoCountry,
         );
         
-        $this->uri = '/PhoneNumbers/Countries/' . $isoCountry . '';
+        $this->uri = '/PhoneNumbers/Countries/' . rawurlencode($isoCountry) . '';
     }
 
     /**

--- a/Twilio/Rest/Pricing/V1/Voice/CountryContext.php
+++ b/Twilio/Rest/Pricing/V1/Voice/CountryContext.php
@@ -29,7 +29,7 @@ class CountryContext extends InstanceContext {
             'isoCountry' => $isoCountry,
         );
         
-        $this->uri = '/Voice/Countries/' . $isoCountry . '';
+        $this->uri = '/Voice/Countries/' . rawurlencode($isoCountry) . '';
     }
 
     /**

--- a/Twilio/Rest/Pricing/V1/Voice/NumberContext.php
+++ b/Twilio/Rest/Pricing/V1/Voice/NumberContext.php
@@ -29,7 +29,7 @@ class NumberContext extends InstanceContext {
             'number' => $number,
         );
         
-        $this->uri = '/Voice/Numbers/' . $number . '';
+        $this->uri = '/Voice/Numbers/' . rawurlencode($number) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/ActivityContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/ActivityContext.php
@@ -31,7 +31,7 @@ class ActivityContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Activities/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Activities/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/ActivityList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/ActivityList.php
@@ -30,7 +30,7 @@ class ActivityList extends ListResource {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Activities';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Activities';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/EventContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/EventContext.php
@@ -31,7 +31,7 @@ class EventContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Events/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Events/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/EventList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/EventList.php
@@ -30,7 +30,7 @@ class EventList extends ListResource {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Events';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Events';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Task/ReservationContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Task/ReservationContext.php
@@ -34,7 +34,7 @@ class ReservationContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Tasks/' . $taskSid . '/Reservations/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Tasks/' . rawurlencode($taskSid) . '/Reservations/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Task/ReservationList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Task/ReservationList.php
@@ -32,7 +32,7 @@ class ReservationList extends ListResource {
             'taskSid' => $taskSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Tasks/' . $taskSid . '/Reservations';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Tasks/' . rawurlencode($taskSid) . '/Reservations';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/TaskChannelContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/TaskChannelContext.php
@@ -31,7 +31,7 @@ class TaskChannelContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/TaskChannels/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/TaskChannels/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/TaskChannelList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/TaskChannelList.php
@@ -29,7 +29,7 @@ class TaskChannelList extends ListResource {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/TaskChannels';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/TaskChannels';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/TaskContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/TaskContext.php
@@ -40,7 +40,7 @@ class TaskContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Tasks/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Tasks/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/TaskList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/TaskList.php
@@ -30,7 +30,7 @@ class TaskList extends ListResource {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Tasks';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Tasks';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueueStatisticsContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueueStatisticsContext.php
@@ -32,7 +32,7 @@ class TaskQueueStatisticsContext extends InstanceContext {
             'taskQueueSid' => $taskQueueSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/TaskQueues/' . $taskQueueSid . '/Statistics';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/TaskQueues/' . rawurlencode($taskQueueSid) . '/Statistics';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueuesStatisticsList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueuesStatisticsList.php
@@ -30,7 +30,7 @@ class TaskQueuesStatisticsList extends ListResource {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/TaskQueues/Statistics';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/TaskQueues/Statistics';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueueContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueueContext.php
@@ -40,7 +40,7 @@ class TaskQueueContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/TaskQueues/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/TaskQueues/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueueList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueueList.php
@@ -37,7 +37,7 @@ class TaskQueueList extends ListResource {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/TaskQueues';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/TaskQueues';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Worker/ReservationContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Worker/ReservationContext.php
@@ -34,7 +34,7 @@ class ReservationContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workers/' . $workerSid . '/Reservations/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workers/' . rawurlencode($workerSid) . '/Reservations/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Worker/ReservationList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Worker/ReservationList.php
@@ -32,7 +32,7 @@ class ReservationList extends ListResource {
             'workerSid' => $workerSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workers/' . $workerSid . '/Reservations';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workers/' . rawurlencode($workerSid) . '/Reservations';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerChannelContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerChannelContext.php
@@ -34,7 +34,7 @@ class WorkerChannelContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workers/' . $workerSid . '/Channels/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workers/' . rawurlencode($workerSid) . '/Channels/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerChannelList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerChannelList.php
@@ -31,7 +31,7 @@ class WorkerChannelList extends ListResource {
             'workerSid' => $workerSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workers/' . $workerSid . '/Channels';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workers/' . rawurlencode($workerSid) . '/Channels';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerStatisticsContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerStatisticsContext.php
@@ -32,7 +32,7 @@ class WorkerStatisticsContext extends InstanceContext {
             'workerSid' => $workerSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workers/' . $workerSid . '/Statistics';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workers/' . rawurlencode($workerSid) . '/Statistics';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkersStatisticsContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkersStatisticsContext.php
@@ -30,7 +30,7 @@ class WorkersStatisticsContext extends InstanceContext {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workers/Statistics';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workers/Statistics';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/WorkerContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/WorkerContext.php
@@ -48,7 +48,7 @@ class WorkerContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workers/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workers/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/WorkerList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/WorkerList.php
@@ -38,7 +38,7 @@ class WorkerList extends ListResource {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workers';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workers';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/Workflow/WorkflowStatisticsContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Workflow/WorkflowStatisticsContext.php
@@ -32,7 +32,7 @@ class WorkflowStatisticsContext extends InstanceContext {
             'workflowSid' => $workflowSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workflows/' . $workflowSid . '/Statistics';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workflows/' . rawurlencode($workflowSid) . '/Statistics';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/WorkflowContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/WorkflowContext.php
@@ -40,7 +40,7 @@ class WorkflowContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workflows/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workflows/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/WorkflowList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/WorkflowList.php
@@ -30,7 +30,7 @@ class WorkflowList extends ListResource {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Workflows';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Workflows';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/Workspace/WorkspaceStatisticsContext.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/WorkspaceStatisticsContext.php
@@ -30,7 +30,7 @@ class WorkspaceStatisticsContext extends InstanceContext {
             'workspaceSid' => $workspaceSid,
         );
         
-        $this->uri = '/Workspaces/' . $workspaceSid . '/Statistics';
+        $this->uri = '/Workspaces/' . rawurlencode($workspaceSid) . '/Statistics';
     }
 
     /**

--- a/Twilio/Rest/Taskrouter/V1/WorkspaceContext.php
+++ b/Twilio/Rest/Taskrouter/V1/WorkspaceContext.php
@@ -66,7 +66,7 @@ class WorkspaceContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Workspaces/' . $sid . '';
+        $this->uri = '/Workspaces/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/Trunk/CredentialListContext.php
+++ b/Twilio/Rest/Trunking/V1/Trunk/CredentialListContext.php
@@ -31,7 +31,7 @@ class CredentialListContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Trunks/' . $trunkSid . '/CredentialLists/' . $sid . '';
+        $this->uri = '/Trunks/' . rawurlencode($trunkSid) . '/CredentialLists/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/Trunk/CredentialListList.php
+++ b/Twilio/Rest/Trunking/V1/Trunk/CredentialListList.php
@@ -29,7 +29,7 @@ class CredentialListList extends ListResource {
             'trunkSid' => $trunkSid,
         );
         
-        $this->uri = '/Trunks/' . $trunkSid . '/CredentialLists';
+        $this->uri = '/Trunks/' . rawurlencode($trunkSid) . '/CredentialLists';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/Trunk/IpAccessControlListContext.php
+++ b/Twilio/Rest/Trunking/V1/Trunk/IpAccessControlListContext.php
@@ -31,7 +31,7 @@ class IpAccessControlListContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Trunks/' . $trunkSid . '/IpAccessControlLists/' . $sid . '';
+        $this->uri = '/Trunks/' . rawurlencode($trunkSid) . '/IpAccessControlLists/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/Trunk/IpAccessControlListList.php
+++ b/Twilio/Rest/Trunking/V1/Trunk/IpAccessControlListList.php
@@ -29,7 +29,7 @@ class IpAccessControlListList extends ListResource {
             'trunkSid' => $trunkSid,
         );
         
-        $this->uri = '/Trunks/' . $trunkSid . '/IpAccessControlLists';
+        $this->uri = '/Trunks/' . rawurlencode($trunkSid) . '/IpAccessControlLists';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/Trunk/OriginationUrlContext.php
+++ b/Twilio/Rest/Trunking/V1/Trunk/OriginationUrlContext.php
@@ -32,7 +32,7 @@ class OriginationUrlContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Trunks/' . $trunkSid . '/OriginationUrls/' . $sid . '';
+        $this->uri = '/Trunks/' . rawurlencode($trunkSid) . '/OriginationUrls/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/Trunk/OriginationUrlList.php
+++ b/Twilio/Rest/Trunking/V1/Trunk/OriginationUrlList.php
@@ -29,7 +29,7 @@ class OriginationUrlList extends ListResource {
             'trunkSid' => $trunkSid,
         );
         
-        $this->uri = '/Trunks/' . $trunkSid . '/OriginationUrls';
+        $this->uri = '/Trunks/' . rawurlencode($trunkSid) . '/OriginationUrls';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/Trunk/PhoneNumberContext.php
+++ b/Twilio/Rest/Trunking/V1/Trunk/PhoneNumberContext.php
@@ -31,7 +31,7 @@ class PhoneNumberContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Trunks/' . $trunkSid . '/PhoneNumbers/' . $sid . '';
+        $this->uri = '/Trunks/' . rawurlencode($trunkSid) . '/PhoneNumbers/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/Trunk/PhoneNumberList.php
+++ b/Twilio/Rest/Trunking/V1/Trunk/PhoneNumberList.php
@@ -29,7 +29,7 @@ class PhoneNumberList extends ListResource {
             'trunkSid' => $trunkSid,
         );
         
-        $this->uri = '/Trunks/' . $trunkSid . '/PhoneNumbers';
+        $this->uri = '/Trunks/' . rawurlencode($trunkSid) . '/PhoneNumbers';
     }
 
     /**

--- a/Twilio/Rest/Trunking/V1/TrunkContext.php
+++ b/Twilio/Rest/Trunking/V1/TrunkContext.php
@@ -50,7 +50,7 @@ class TrunkContext extends InstanceContext {
             'sid' => $sid,
         );
         
-        $this->uri = '/Trunks/' . $sid . '';
+        $this->uri = '/Trunks/' . rawurlencode($sid) . '';
     }
 
     /**

--- a/Twilio/Tests/Holodeck.php
+++ b/Twilio/Tests/Holodeck.php
@@ -27,6 +27,22 @@ class Holodeck implements Client {
         $this->response = $response;
     }
 
+    public function assertRequest($request) {
+        if ($this->hasRequest($request)) {
+            return;
+        }
+
+        $message = "Failed asserting that the following request exists: \n";
+        $message .= ' - ' . $this->printRequest($request);
+        $message .= "\n" . str_repeat('-', 3) . "\n";
+        $message .= "Candidate Requests:\n";
+        foreach ($this->requests as $candidate) {
+            $message .= ' + ' . $this->printRequest($candidate) . "\n";
+        }
+
+        throw new \PHPUnit_Framework_ExpectationFailedException($message);
+    }
+
     public function hasRequest($request) {
         for ($i = 0; $i < count($this->requests); $i++) {
             $c = $this->requests[$i];
@@ -39,5 +55,19 @@ class Holodeck implements Client {
         }
 
         return false;
+    }
+
+    protected function printRequest($request) {
+        $url = $request->url;
+        if ($request->params) {
+            $url .= '?' . http_build_query($request->params);
+        }
+
+
+        $data = $request->data
+              ? '-d ' . http_build_query($request->data)
+              : '';
+
+        return implode(' ', array(strtoupper($request->method), $url, $data));
     }
 }

--- a/Twilio/Tests/HolodeckTestCase.php
+++ b/Twilio/Tests/HolodeckTestCase.php
@@ -22,4 +22,9 @@ class HolodeckTestCase extends PHPUnit_Framework_TestCase
         $this->twilio = null;
         $this->holodeck = null;
     }
+
+    public function assertRequest($request) {
+        $this->holodeck->assertRequest($request);
+        $this->assertTrue(true);
+    }
 }

--- a/Twilio/Tests/Integration/Api/V2010/Account/Address/DependentPhoneNumberTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Address/DependentPhoneNumberTest.php
@@ -26,10 +26,10 @@ class DependentPhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses/ADaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/DependentPhoneNumbers.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -70,7 +70,7 @@ class DependentPhoneNumberTest extends HolodeckTestCase {
                                            ->addresses("ADaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->dependentPhoneNumbers->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/AddressTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/AddressTest.php
@@ -34,12 +34,12 @@ class AddressTest extends HolodeckTestCase {
             'IsoCountry' => "US",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -78,10 +78,10 @@ class AddressTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses/ADaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -105,10 +105,10 @@ class AddressTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses/ADaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -147,10 +147,10 @@ class AddressTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses/ADaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -189,10 +189,10 @@ class AddressTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -234,7 +234,7 @@ class AddressTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->addresses->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/ApplicationTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/ApplicationTest.php
@@ -29,12 +29,12 @@ class ApplicationTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Applications.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -81,10 +81,10 @@ class ApplicationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Applications/APaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -108,10 +108,10 @@ class ApplicationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Applications/APaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -158,10 +158,10 @@ class ApplicationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Applications.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -211,7 +211,7 @@ class ApplicationTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->applications->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -250,10 +250,10 @@ class ApplicationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Applications/APaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/AuthorizedConnectAppTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/AuthorizedConnectAppTest.php
@@ -25,10 +25,10 @@ class AuthorizedConnectAppTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AuthorizedConnectApps/CNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -67,10 +67,10 @@ class AuthorizedConnectAppTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AuthorizedConnectApps.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -112,7 +112,7 @@ class AuthorizedConnectAppTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->authorizedConnectApps->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/AvailablePhoneNumberCountry/LocalTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/AvailablePhoneNumberCountry/LocalTest.php
@@ -26,10 +26,10 @@ class LocalTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AvailablePhoneNumbers/US/Local.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -76,7 +76,7 @@ class LocalTest extends HolodeckTestCase {
                                            ->availablePhoneNumbers("US")
                                            ->local->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/AvailablePhoneNumberCountry/MobileTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/AvailablePhoneNumberCountry/MobileTest.php
@@ -26,10 +26,10 @@ class MobileTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AvailablePhoneNumbers/US/Mobile.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -75,7 +75,7 @@ class MobileTest extends HolodeckTestCase {
                                            ->availablePhoneNumbers("US")
                                            ->mobile->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/AvailablePhoneNumberCountry/TollFreeTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/AvailablePhoneNumberCountry/TollFreeTest.php
@@ -26,10 +26,10 @@ class TollFreeTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AvailablePhoneNumbers/US/TollFree.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -75,7 +75,7 @@ class TollFreeTest extends HolodeckTestCase {
                                            ->availablePhoneNumbers("US")
                                            ->tollFree->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/AvailablePhoneNumberCountryTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/AvailablePhoneNumberCountryTest.php
@@ -25,10 +25,10 @@ class AvailablePhoneNumberCountryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AvailablePhoneNumbers.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -65,7 +65,7 @@ class AvailablePhoneNumberCountryTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->availablePhoneNumbers->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -104,10 +104,10 @@ class AvailablePhoneNumberCountryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AvailablePhoneNumbers/US.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Call/FeedbackSummaryTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Call/FeedbackSummaryTest.php
@@ -31,12 +31,12 @@ class FeedbackSummaryTest extends HolodeckTestCase {
             'EndDate' => new \DateTime('2008-01-02'),
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/FeedbackSummary.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -85,10 +85,10 @@ class FeedbackSummaryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/FeedbackSummary/FSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -137,10 +137,10 @@ class FeedbackSummaryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/FeedbackSummary/FSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Call/FeedbackTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Call/FeedbackTest.php
@@ -30,12 +30,12 @@ class FeedbackTest extends HolodeckTestCase {
             'QualityScore' => 1,
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Feedback.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -73,10 +73,10 @@ class FeedbackTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Feedback.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -118,12 +118,12 @@ class FeedbackTest extends HolodeckTestCase {
             'QualityScore' => 1,
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Feedback.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Call/NotificationTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Call/NotificationTest.php
@@ -26,10 +26,10 @@ class NotificationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications/NOaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -75,10 +75,10 @@ class NotificationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications/NOaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -104,10 +104,10 @@ class NotificationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -152,7 +152,7 @@ class NotificationTest extends HolodeckTestCase {
                                            ->calls("CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->notifications->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Call/RecordingTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Call/RecordingTest.php
@@ -26,10 +26,10 @@ class RecordingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings/REaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -67,10 +67,10 @@ class RecordingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings/REaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -96,10 +96,10 @@ class RecordingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -139,7 +139,7 @@ class RecordingTest extends HolodeckTestCase {
                                            ->calls("CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->recordings->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/CallTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/CallTest.php
@@ -30,12 +30,12 @@ class CallTest extends HolodeckTestCase {
             'From' => "+987654321",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -90,10 +90,10 @@ class CallTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -117,10 +117,10 @@ class CallTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -175,10 +175,10 @@ class CallTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -236,7 +236,7 @@ class CallTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->calls->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -275,10 +275,10 @@ class CallTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Conference/ParticipantTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Conference/ParticipantTest.php
@@ -26,10 +26,10 @@ class ParticipantTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences/CFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Participants/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -71,12 +71,12 @@ class ParticipantTest extends HolodeckTestCase {
             'Muted' => True,
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences/CFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Participants/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -114,10 +114,10 @@ class ParticipantTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences/CFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Participants/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -143,10 +143,10 @@ class ParticipantTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences/CFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Participants.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -186,7 +186,7 @@ class ParticipantTest extends HolodeckTestCase {
                                            ->conferences("CFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->participants->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/ConferenceTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/ConferenceTest.php
@@ -25,10 +25,10 @@ class ConferenceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences/CFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -66,10 +66,10 @@ class ConferenceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -110,7 +110,7 @@ class ConferenceTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->conferences->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/ConnectAppTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/ConnectAppTest.php
@@ -25,10 +25,10 @@ class ConnectAppTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/ConnectApps/CNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -66,10 +66,10 @@ class ConnectAppTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/ConnectApps/CNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -107,10 +107,10 @@ class ConnectAppTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/ConnectApps.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -151,7 +151,7 @@ class ConnectAppTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->connectApps->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/IncomingPhoneNumber/LocalTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/IncomingPhoneNumber/LocalTest.php
@@ -26,10 +26,10 @@ class LocalTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/Local.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -89,7 +89,7 @@ class LocalTest extends HolodeckTestCase {
                                            ->incomingPhoneNumbers
                                            ->local->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -134,12 +134,12 @@ class LocalTest extends HolodeckTestCase {
             'PhoneNumber' => "+987654321",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/Local.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/IncomingPhoneNumber/MobileTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/IncomingPhoneNumber/MobileTest.php
@@ -26,10 +26,10 @@ class MobileTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/Mobile.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -89,7 +89,7 @@ class MobileTest extends HolodeckTestCase {
                                            ->incomingPhoneNumbers
                                            ->mobile->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -134,12 +134,12 @@ class MobileTest extends HolodeckTestCase {
             'PhoneNumber' => "+987654321",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/Mobile.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/IncomingPhoneNumber/TollFreeTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/IncomingPhoneNumber/TollFreeTest.php
@@ -26,10 +26,10 @@ class TollFreeTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/TollFree.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -89,7 +89,7 @@ class TollFreeTest extends HolodeckTestCase {
                                            ->incomingPhoneNumbers
                                            ->tollFree->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -134,12 +134,12 @@ class TollFreeTest extends HolodeckTestCase {
             'PhoneNumber' => "+987654321",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/TollFree.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/IncomingPhoneNumberTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/IncomingPhoneNumberTest.php
@@ -25,10 +25,10 @@ class IncomingPhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -84,10 +84,10 @@ class IncomingPhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -143,10 +143,10 @@ class IncomingPhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers/PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -170,10 +170,10 @@ class IncomingPhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -232,7 +232,7 @@ class IncomingPhoneNumberTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->incomingPhoneNumbers->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -271,10 +271,10 @@ class IncomingPhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json'
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/KeyTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/KeyTest.php
@@ -25,10 +25,10 @@ class KeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Keys/SKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -59,10 +59,10 @@ class KeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Keys/SKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -93,10 +93,10 @@ class KeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Keys/SKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -120,10 +120,10 @@ class KeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Keys.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -154,7 +154,7 @@ class KeyTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->keys->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Message/FeedbackTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Message/FeedbackTest.php
@@ -26,9 +26,9 @@ class FeedbackTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/MMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Feedback.json'
-        )));
+        ));
     }
 }

--- a/Twilio/Tests/Integration/Api/V2010/Account/Message/MediaTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Message/MediaTest.php
@@ -26,10 +26,10 @@ class MediaTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/MMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Media/MEaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -55,10 +55,10 @@ class MediaTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/MMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Media/MEaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -94,10 +94,10 @@ class MediaTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/MMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Media.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -135,7 +135,7 @@ class MediaTest extends HolodeckTestCase {
                                            ->messages("MMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->media->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/MessageTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/MessageTest.php
@@ -29,12 +29,12 @@ class MessageTest extends HolodeckTestCase {
             'To' => "+123456789",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -82,10 +82,10 @@ class MessageTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/MMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -109,10 +109,10 @@ class MessageTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/MMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -160,10 +160,10 @@ class MessageTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -214,7 +214,7 @@ class MessageTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->messages->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -253,10 +253,10 @@ class MessageTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/MMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/NewKeyTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/NewKeyTest.php
@@ -25,10 +25,10 @@ class NewKeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Keys.json'
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/NewSigningKeyTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/NewSigningKeyTest.php
@@ -25,10 +25,10 @@ class NewSigningKeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SigningKeys.json'
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/NotificationTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/NotificationTest.php
@@ -25,10 +25,10 @@ class NotificationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications/NOaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -72,10 +72,10 @@ class NotificationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications/NOaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -99,10 +99,10 @@ class NotificationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -146,7 +146,7 @@ class NotificationTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->notifications->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/OutgoingCallerIdTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/OutgoingCallerIdTest.php
@@ -25,10 +25,10 @@ class OutgoingCallerIdTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OutgoingCallerIds/PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -62,10 +62,10 @@ class OutgoingCallerIdTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OutgoingCallerIds/PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -99,10 +99,10 @@ class OutgoingCallerIdTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OutgoingCallerIds/PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -126,10 +126,10 @@ class OutgoingCallerIdTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OutgoingCallerIds.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -166,7 +166,7 @@ class OutgoingCallerIdTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->outgoingCallerIds->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Queue/MemberTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Queue/MemberTest.php
@@ -26,10 +26,10 @@ class MemberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues/QUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Members/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -68,12 +68,12 @@ class MemberTest extends HolodeckTestCase {
             'Method' => "GET",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues/QUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Members/CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -107,10 +107,10 @@ class MemberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues/QUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Members.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -146,7 +146,7 @@ class MemberTest extends HolodeckTestCase {
                                            ->queues("QUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->members->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/QueueTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/QueueTest.php
@@ -25,10 +25,10 @@ class QueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues/QUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -64,10 +64,10 @@ class QueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues/QUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -103,10 +103,10 @@ class QueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues/QUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -130,10 +130,10 @@ class QueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -172,7 +172,7 @@ class QueueTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->queues->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -211,10 +211,10 @@ class QueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues.json'
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Recording/TranscriptionTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Recording/TranscriptionTest.php
@@ -26,10 +26,10 @@ class TranscriptionTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings/REaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -71,10 +71,10 @@ class TranscriptionTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings/REaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -100,10 +100,10 @@ class TranscriptionTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings/REaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -147,7 +147,7 @@ class TranscriptionTest extends HolodeckTestCase {
                                            ->recordings("REaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->transcriptions->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/RecordingTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/RecordingTest.php
@@ -25,10 +25,10 @@ class RecordingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings/REaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -68,10 +68,10 @@ class RecordingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings/REaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -95,10 +95,10 @@ class RecordingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -141,7 +141,7 @@ class RecordingTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->recordings->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/SandboxTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/SandboxTest.php
@@ -25,10 +25,10 @@ class SandboxTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Sandbox.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -69,10 +69,10 @@ class SandboxTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Sandbox.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/ShortCodeTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/ShortCodeTest.php
@@ -25,10 +25,10 @@ class ShortCodeTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SMS/ShortCodes/SCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -67,10 +67,10 @@ class ShortCodeTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SMS/ShortCodes/SCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -109,10 +109,10 @@ class ShortCodeTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SMS/ShortCodes.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -154,7 +154,7 @@ class ShortCodeTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->shortCodes->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/SigningKeyTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/SigningKeyTest.php
@@ -25,10 +25,10 @@ class SigningKeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SigningKeys/SKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -59,10 +59,10 @@ class SigningKeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SigningKeys/SKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -93,10 +93,10 @@ class SigningKeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SigningKeys/SKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -120,10 +120,10 @@ class SigningKeyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SigningKeys.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -154,7 +154,7 @@ class SigningKeyTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->signingKeys->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Sip/CredentialList/CredentialTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Sip/CredentialList/CredentialTest.php
@@ -27,10 +27,10 @@ class CredentialTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Credentials.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -69,7 +69,7 @@ class CredentialTest extends HolodeckTestCase {
                                            ->credentialLists("CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->credentials->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -117,12 +117,12 @@ class CredentialTest extends HolodeckTestCase {
             'Password' => "password",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Credentials.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -160,10 +160,10 @@ class CredentialTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Credentials/CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -206,12 +206,12 @@ class CredentialTest extends HolodeckTestCase {
             'Password' => "password",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Credentials/CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -249,10 +249,10 @@ class CredentialTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Credentials/CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Sip/CredentialListTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Sip/CredentialListTest.php
@@ -26,10 +26,10 @@ class CredentialListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -64,7 +64,7 @@ class CredentialListTest extends HolodeckTestCase {
                                            ->sip
                                            ->credentialLists->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -104,12 +104,12 @@ class CredentialListTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -147,10 +147,10 @@ class CredentialListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -192,12 +192,12 @@ class CredentialListTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -235,10 +235,10 @@ class CredentialListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Sip/Domain/CredentialListMappingTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Sip/Domain/CredentialListMappingTest.php
@@ -31,12 +31,12 @@ class CredentialListMappingTest extends HolodeckTestCase {
             'CredentialListSid' => "CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CredentialListMappings.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -76,10 +76,10 @@ class CredentialListMappingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CredentialListMappings.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -115,7 +115,7 @@ class CredentialListMappingTest extends HolodeckTestCase {
                                            ->domains("SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->credentialListMappings->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -153,10 +153,10 @@ class CredentialListMappingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CredentialListMappings/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -196,10 +196,10 @@ class CredentialListMappingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CredentialListMappings/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Sip/Domain/IpAccessControlListMappingTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Sip/Domain/IpAccessControlListMappingTest.php
@@ -27,10 +27,10 @@ class IpAccessControlListMappingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAccessControlListMappings/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -74,12 +74,12 @@ class IpAccessControlListMappingTest extends HolodeckTestCase {
             'IpAccessControlListSid' => "ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAccessControlListMappings.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -119,10 +119,10 @@ class IpAccessControlListMappingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAccessControlListMappings.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -163,7 +163,7 @@ class IpAccessControlListMappingTest extends HolodeckTestCase {
                                            ->domains("SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->ipAccessControlListMappings->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -206,10 +206,10 @@ class IpAccessControlListMappingTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAccessControlListMappings/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Sip/DomainTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Sip/DomainTest.php
@@ -26,10 +26,10 @@ class DomainTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -74,7 +74,7 @@ class DomainTest extends HolodeckTestCase {
                                            ->sip
                                            ->domains->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -114,12 +114,12 @@ class DomainTest extends HolodeckTestCase {
             'DomainName' => "domainName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -167,10 +167,10 @@ class DomainTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -218,10 +218,10 @@ class DomainTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -269,10 +269,10 @@ class DomainTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Sip/IpAccessControlList/IpAddressTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Sip/IpAccessControlList/IpAddressTest.php
@@ -27,10 +27,10 @@ class IpAddressTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAddresses.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -70,7 +70,7 @@ class IpAddressTest extends HolodeckTestCase {
                                            ->ipAccessControlLists("ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->ipAddresses->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -118,12 +118,12 @@ class IpAddressTest extends HolodeckTestCase {
             'IpAddress' => "ipAddress",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAddresses.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -162,10 +162,10 @@ class IpAddressTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAddresses/IPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -204,10 +204,10 @@ class IpAddressTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAddresses/IPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -246,10 +246,10 @@ class IpAddressTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAddresses/IPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Sip/IpAccessControlListTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Sip/IpAccessControlListTest.php
@@ -26,10 +26,10 @@ class IpAccessControlListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -69,7 +69,7 @@ class IpAccessControlListTest extends HolodeckTestCase {
                                            ->sip
                                            ->ipAccessControlLists->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -114,12 +114,12 @@ class IpAccessControlListTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -157,10 +157,10 @@ class IpAccessControlListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -202,12 +202,12 @@ class IpAccessControlListTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -245,10 +245,10 @@ class IpAccessControlListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/TokenTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/TokenTest.php
@@ -25,10 +25,10 @@ class TokenTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tokens.json'
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/TranscriptionTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/TranscriptionTest.php
@@ -25,10 +25,10 @@ class TranscriptionTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -68,10 +68,10 @@ class TranscriptionTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -95,10 +95,10 @@ class TranscriptionTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -141,7 +141,7 @@ class TranscriptionTest extends HolodeckTestCase {
         $actual = $this->twilio->api->v2010->accounts("ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                            ->transcriptions->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/AllTimeTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/AllTimeTest.php
@@ -27,10 +27,10 @@ class AllTimeTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records/AllTime.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -85,7 +85,7 @@ class AllTimeTest extends HolodeckTestCase {
                                            ->records
                                            ->allTime->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/DailyTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/DailyTest.php
@@ -27,10 +27,10 @@ class DailyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records/Daily.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -85,7 +85,7 @@ class DailyTest extends HolodeckTestCase {
                                            ->records
                                            ->daily->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/LastMonthTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/LastMonthTest.php
@@ -27,10 +27,10 @@ class LastMonthTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records/LastMonth.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -85,7 +85,7 @@ class LastMonthTest extends HolodeckTestCase {
                                            ->records
                                            ->lastMonth->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/MonthlyTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/MonthlyTest.php
@@ -27,10 +27,10 @@ class MonthlyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records/Monthly.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -85,7 +85,7 @@ class MonthlyTest extends HolodeckTestCase {
                                            ->records
                                            ->monthly->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/ThisMonthTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/ThisMonthTest.php
@@ -27,10 +27,10 @@ class ThisMonthTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records/ThisMonth.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -85,7 +85,7 @@ class ThisMonthTest extends HolodeckTestCase {
                                            ->records
                                            ->thisMonth->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/TodayTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/TodayTest.php
@@ -27,10 +27,10 @@ class TodayTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records/Today.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -85,7 +85,7 @@ class TodayTest extends HolodeckTestCase {
                                            ->records
                                            ->today->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/YearlyTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/YearlyTest.php
@@ -27,10 +27,10 @@ class YearlyTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records/Yearly.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -85,7 +85,7 @@ class YearlyTest extends HolodeckTestCase {
                                            ->records
                                            ->yearly->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/YesterdayTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/Record/YesterdayTest.php
@@ -27,10 +27,10 @@ class YesterdayTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records/Yesterday.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -85,7 +85,7 @@ class YesterdayTest extends HolodeckTestCase {
                                            ->records
                                            ->yesterday->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/RecordTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/RecordTest.php
@@ -26,10 +26,10 @@ class RecordTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Records.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -83,7 +83,7 @@ class RecordTest extends HolodeckTestCase {
                                            ->usage
                                            ->records->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/Usage/TriggerTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/Usage/TriggerTest.php
@@ -26,10 +26,10 @@ class TriggerTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Triggers/UTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -74,10 +74,10 @@ class TriggerTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Triggers/UTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -122,10 +122,10 @@ class TriggerTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Triggers/UTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -157,12 +157,12 @@ class TriggerTest extends HolodeckTestCase {
             'UsageCategory' => "authy-authentications",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Triggers.json',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -207,10 +207,10 @@ class TriggerTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage/Triggers.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -257,7 +257,7 @@ class TriggerTest extends HolodeckTestCase {
                                            ->usage
                                            ->triggers->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Api/V2010/Account/ValidationRequestTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/Account/ValidationRequestTest.php
@@ -29,11 +29,11 @@ class ValidationRequestTest extends HolodeckTestCase {
             'PhoneNumber' => "+987654321",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OutgoingCallerIds.json',
             null,
             $values
-        )));
+        ));
     }
 }

--- a/Twilio/Tests/Integration/Api/V2010/AccountTest.php
+++ b/Twilio/Tests/Integration/Api/V2010/AccountTest.php
@@ -24,10 +24,10 @@ class AccountTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts.json'
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -73,10 +73,10 @@ class AccountTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -122,10 +122,10 @@ class AccountTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://api.twilio.com/2010-04-01/Accounts.json'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -183,7 +183,7 @@ class AccountTest extends HolodeckTestCase {
         
         $actual = $this->twilio->api->v2010->accounts->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -220,10 +220,10 @@ class AccountTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/IpMessaging/V1/CredentialTest.php
+++ b/Twilio/Tests/Integration/IpMessaging/V1/CredentialTest.php
@@ -24,10 +24,10 @@ class CredentialTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Credentials'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -62,7 +62,7 @@ class CredentialTest extends HolodeckTestCase {
         
         $actual = $this->twilio->ipMessaging->v1->credentials->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -101,12 +101,12 @@ class CredentialTest extends HolodeckTestCase {
             'Type' => "gcm",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Credentials',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -139,10 +139,10 @@ class CredentialTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Credentials/CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -175,10 +175,10 @@ class CredentialTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Credentials/CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -211,10 +211,10 @@ class CredentialTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://ip-messaging.twilio.com/v1/Credentials/CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/IpMessaging/V1/Service/Channel/MemberTest.php
+++ b/Twilio/Tests/Integration/IpMessaging/V1/Service/Channel/MemberTest.php
@@ -26,10 +26,10 @@ class MemberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Members/MBaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -73,12 +73,12 @@ class MemberTest extends HolodeckTestCase {
             'Identity' => "identity",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Members',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -118,10 +118,10 @@ class MemberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Members'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -161,7 +161,7 @@ class MemberTest extends HolodeckTestCase {
                                                 ->channels("CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                 ->members->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -200,10 +200,10 @@ class MemberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Members/MBaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/IpMessaging/V1/Service/Channel/MessageTest.php
+++ b/Twilio/Tests/Integration/IpMessaging/V1/Service/Channel/MessageTest.php
@@ -26,10 +26,10 @@ class MessageTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/IMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testCreateRequest() {
@@ -46,12 +46,12 @@ class MessageTest extends HolodeckTestCase {
             'Body' => "body",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages',
             null,
             $values
-        )));
+        ));
     }
 
     public function testReadRequest() {
@@ -64,10 +64,10 @@ class MessageTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages'
-        )));
+        ));
     }
 
     public function testDeleteRequest() {
@@ -80,10 +80,10 @@ class MessageTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/IMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateRequest() {
@@ -100,11 +100,11 @@ class MessageTest extends HolodeckTestCase {
             'Body' => "body",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages/IMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             null,
             $values
-        )));
+        ));
     }
 }

--- a/Twilio/Tests/Integration/IpMessaging/V1/Service/ChannelTest.php
+++ b/Twilio/Tests/Integration/IpMessaging/V1/Service/ChannelTest.php
@@ -25,10 +25,10 @@ class ChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -70,10 +70,10 @@ class ChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -97,10 +97,10 @@ class ChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels'
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -142,10 +142,10 @@ class ChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -188,7 +188,7 @@ class ChannelTest extends HolodeckTestCase {
         $actual = $this->twilio->ipMessaging->v1->services("ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                 ->channels->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -225,10 +225,10 @@ class ChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/CHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/IpMessaging/V1/Service/RoleTest.php
+++ b/Twilio/Tests/Integration/IpMessaging/V1/Service/RoleTest.php
@@ -25,10 +25,10 @@ class RoleTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Roles/RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -69,10 +69,10 @@ class RoleTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Roles/RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -102,12 +102,12 @@ class RoleTest extends HolodeckTestCase {
             'Permission' => array('permission'),
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Roles',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -148,10 +148,10 @@ class RoleTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Roles'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -193,7 +193,7 @@ class RoleTest extends HolodeckTestCase {
         $actual = $this->twilio->ipMessaging->v1->services("ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                 ->roles->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -235,12 +235,12 @@ class RoleTest extends HolodeckTestCase {
             'Permission' => array('permission'),
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Roles/RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             null,
             $values
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/IpMessaging/V1/Service/UserTest.php
+++ b/Twilio/Tests/Integration/IpMessaging/V1/Service/UserTest.php
@@ -25,10 +25,10 @@ class UserTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Users/USaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -65,10 +65,10 @@ class UserTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Users/USaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -97,12 +97,12 @@ class UserTest extends HolodeckTestCase {
             'RoleSid' => "RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Users',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -139,10 +139,10 @@ class UserTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Users'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -180,7 +180,7 @@ class UserTest extends HolodeckTestCase {
         $actual = $this->twilio->ipMessaging->v1->services("ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                 ->users->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -217,10 +217,10 @@ class UserTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Users/USaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/IpMessaging/V1/ServiceTest.php
+++ b/Twilio/Tests/Integration/IpMessaging/V1/ServiceTest.php
@@ -24,10 +24,10 @@ class ServiceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -70,10 +70,10 @@ class ServiceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -99,12 +99,12 @@ class ServiceTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -147,10 +147,10 @@ class ServiceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://ip-messaging.twilio.com/v1/Services'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -195,7 +195,7 @@ class ServiceTest extends HolodeckTestCase {
         
         $actual = $this->twilio->ipMessaging->v1->services->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -230,10 +230,10 @@ class ServiceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://ip-messaging.twilio.com/v1/Services/ISaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Lookups/V1/PhoneNumberTest.php
+++ b/Twilio/Tests/Integration/Lookups/V1/PhoneNumberTest.php
@@ -24,10 +24,10 @@ class PhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
-            'https://lookups.twilio.com/v1/PhoneNumbers/+987654321'
-        )));
+            'https://lookups.twilio.com/v1/PhoneNumbers/%2B987654321'
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Monitor/V1/AlertTest.php
+++ b/Twilio/Tests/Integration/Monitor/V1/AlertTest.php
@@ -24,10 +24,10 @@ class AlertTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://monitor.twilio.com/v1/Alerts/NOaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -69,10 +69,10 @@ class AlertTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://monitor.twilio.com/v1/Alerts/NOaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -94,10 +94,10 @@ class AlertTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://monitor.twilio.com/v1/Alerts'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -138,7 +138,7 @@ class AlertTest extends HolodeckTestCase {
         
         $actual = $this->twilio->monitor->v1->alerts->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Monitor/V1/EventTest.php
+++ b/Twilio/Tests/Integration/Monitor/V1/EventTest.php
@@ -24,10 +24,10 @@ class EventTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://monitor.twilio.com/v1/Events/AEaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -74,10 +74,10 @@ class EventTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://monitor.twilio.com/v1/Events'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -126,7 +126,7 @@ class EventTest extends HolodeckTestCase {
         
         $actual = $this->twilio->monitor->v1->events->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Pricing/V1/Messaging/CountryTest.php
+++ b/Twilio/Tests/Integration/Pricing/V1/Messaging/CountryTest.php
@@ -25,10 +25,10 @@ class CountryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://pricing.twilio.com/v1/Messaging/Countries'
-        )));
+        ));
     }
 
     public function testFetchRequest() {
@@ -40,9 +40,9 @@ class CountryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://pricing.twilio.com/v1/Messaging/Countries/US'
-        )));
+        ));
     }
 }

--- a/Twilio/Tests/Integration/Pricing/V1/PhoneNumber/CountryTest.php
+++ b/Twilio/Tests/Integration/Pricing/V1/PhoneNumber/CountryTest.php
@@ -25,10 +25,10 @@ class CountryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://pricing.twilio.com/v1/PhoneNumbers/Countries'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -59,7 +59,7 @@ class CountryTest extends HolodeckTestCase {
         $actual = $this->twilio->pricing->v1->phoneNumbers
                                             ->countries->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -96,10 +96,10 @@ class CountryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://pricing.twilio.com/v1/PhoneNumbers/Countries/US'
-        )));
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Pricing/V1/Voice/CountryTest.php
+++ b/Twilio/Tests/Integration/Pricing/V1/Voice/CountryTest.php
@@ -25,10 +25,10 @@ class CountryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://pricing.twilio.com/v1/Voice/Countries'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -59,7 +59,7 @@ class CountryTest extends HolodeckTestCase {
         $actual = $this->twilio->pricing->v1->voice
                                             ->countries->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -96,10 +96,10 @@ class CountryTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://pricing.twilio.com/v1/Voice/Countries/US'
-        )));
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Pricing/V1/Voice/NumberTest.php
+++ b/Twilio/Tests/Integration/Pricing/V1/Voice/NumberTest.php
@@ -25,10 +25,10 @@ class NumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
-            'https://pricing.twilio.com/v1/Voice/Numbers/+987654321'
-        )));
+            'https://pricing.twilio.com/v1/Voice/Numbers/%2B987654321'
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/ActivityTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/ActivityTest.php
@@ -25,10 +25,10 @@ class ActivityTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Activities/WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -67,12 +67,12 @@ class ActivityTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Activities/WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             null,
             $values
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -107,10 +107,10 @@ class ActivityTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Activities/WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -134,10 +134,10 @@ class ActivityTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Activities'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -174,7 +174,7 @@ class ActivityTest extends HolodeckTestCase {
         $actual = $this->twilio->taskrouter->v1->workspaces("WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->activities->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -217,12 +217,12 @@ class ActivityTest extends HolodeckTestCase {
             'Available' => True,
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Activities',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/EventTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/EventTest.php
@@ -25,10 +25,10 @@ class EventTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Events/EVaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -79,10 +79,10 @@ class EventTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Events'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -134,7 +134,7 @@ class EventTest extends HolodeckTestCase {
         $actual = $this->twilio->taskrouter->v1->workspaces("WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->events->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Task/ReservationTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Task/ReservationTest.php
@@ -26,10 +26,10 @@ class ReservationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tasks/WTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Reservations'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -73,7 +73,7 @@ class ReservationTest extends HolodeckTestCase {
                                                ->tasks("WTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->reservations->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -112,10 +112,10 @@ class ReservationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tasks/WTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Reservations/WRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -159,10 +159,10 @@ class ReservationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tasks/WTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Reservations/WRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskChannelTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskChannelTest.php
@@ -25,10 +25,10 @@ class TaskChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskChannels/TCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -63,10 +63,10 @@ class TaskChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskChannels'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -103,7 +103,7 @@ class TaskChannelTest extends HolodeckTestCase {
         $actual = $this->twilio->taskrouter->v1->workspaces("WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->taskChannels->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskQueue/TaskQueueStatisticsTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskQueue/TaskQueueStatisticsTest.php
@@ -26,10 +26,10 @@ class TaskQueueStatisticsTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Statistics'
-        )));
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskQueue/TaskQueuesStatisticsTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskQueue/TaskQueuesStatisticsTest.php
@@ -26,10 +26,10 @@ class TaskQueuesStatisticsTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/Statistics'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -120,7 +120,7 @@ class TaskQueuesStatisticsTest extends HolodeckTestCase {
                                                ->taskQueues
                                                ->statistics->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskQueueTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskQueueTest.php
@@ -25,10 +25,10 @@ class TaskQueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -73,10 +73,10 @@ class TaskQueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -121,10 +121,10 @@ class TaskQueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -170,7 +170,7 @@ class TaskQueueTest extends HolodeckTestCase {
         $actual = $this->twilio->taskrouter->v1->workspaces("WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->taskQueues->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -213,12 +213,12 @@ class TaskQueueTest extends HolodeckTestCase {
             'AssignmentActivitySid' => "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -263,10 +263,10 @@ class TaskQueueTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/TaskTest.php
@@ -25,10 +25,10 @@ class TaskTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tasks/WTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -71,10 +71,10 @@ class TaskTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tasks/WTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -117,10 +117,10 @@ class TaskTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tasks/WTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -144,10 +144,10 @@ class TaskTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tasks'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -192,7 +192,7 @@ class TaskTest extends HolodeckTestCase {
         $actual = $this->twilio->taskrouter->v1->workspaces("WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->tasks->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -235,12 +235,12 @@ class TaskTest extends HolodeckTestCase {
             'WorkflowSid' => "WFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Tasks',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Worker/ReservationTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Worker/ReservationTest.php
@@ -26,10 +26,10 @@ class ReservationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Reservations'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -73,7 +73,7 @@ class ReservationTest extends HolodeckTestCase {
                                                ->workers("WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->reservations->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -112,10 +112,10 @@ class ReservationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Reservations/WRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -159,10 +159,10 @@ class ReservationTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Reservations/WRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Worker/WorkerChannelTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Worker/WorkerChannelTest.php
@@ -26,10 +26,10 @@ class WorkerChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -76,7 +76,7 @@ class WorkerChannelTest extends HolodeckTestCase {
                                                ->workers("WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->workerChannels->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -115,10 +115,10 @@ class WorkerChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/WCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -165,10 +165,10 @@ class WorkerChannelTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Channels/WCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Worker/WorkerStatisticsTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Worker/WorkerStatisticsTest.php
@@ -26,10 +26,10 @@ class WorkerStatisticsTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Statistics'
-        )));
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Worker/WorkersStatisticsTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Worker/WorkersStatisticsTest.php
@@ -26,10 +26,10 @@ class WorkersStatisticsTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/Statistics'
-        )));
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/WorkerTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/WorkerTest.php
@@ -25,10 +25,10 @@ class WorkerTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -72,7 +72,7 @@ class WorkerTest extends HolodeckTestCase {
         $actual = $this->twilio->taskrouter->v1->workspaces("WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->workers->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -113,12 +113,12 @@ class WorkerTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -157,10 +157,10 @@ class WorkerTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -199,10 +199,10 @@ class WorkerTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -241,10 +241,10 @@ class WorkerTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workers/WKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Workflow/WorkflowStatisticsTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/Workflow/WorkflowStatisticsTest.php
@@ -26,10 +26,10 @@ class WorkflowStatisticsTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Statistics'
-        )));
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/WorkflowTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/WorkflowTest.php
@@ -25,10 +25,10 @@ class WorkflowTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -67,10 +67,10 @@ class WorkflowTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -109,10 +109,10 @@ class WorkflowTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -136,10 +136,10 @@ class WorkflowTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -180,7 +180,7 @@ class WorkflowTest extends HolodeckTestCase {
         $actual = $this->twilio->taskrouter->v1->workspaces("WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                ->workflows->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -224,12 +224,12 @@ class WorkflowTest extends HolodeckTestCase {
             'AssignmentCallbackUrl' => "https://example.com",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/Workspace/WorkspaceStatisticsTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/Workspace/WorkspaceStatisticsTest.php
@@ -25,10 +25,10 @@ class WorkspaceStatisticsTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Statistics'
-        )));
+        ));
     }
 
     public function testFetchResponse() {

--- a/Twilio/Tests/Integration/Taskrouter/V1/WorkspaceTest.php
+++ b/Twilio/Tests/Integration/Taskrouter/V1/WorkspaceTest.php
@@ -24,10 +24,10 @@ class WorkspaceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -71,10 +71,10 @@ class WorkspaceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {
@@ -118,10 +118,10 @@ class WorkspaceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://taskrouter.twilio.com/v1/Workspaces'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -167,7 +167,7 @@ class WorkspaceTest extends HolodeckTestCase {
         
         $actual = $this->twilio->taskrouter->v1->workspaces->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -206,12 +206,12 @@ class WorkspaceTest extends HolodeckTestCase {
             'FriendlyName' => "friendlyName",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://taskrouter.twilio.com/v1/Workspaces',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -255,10 +255,10 @@ class WorkspaceTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {

--- a/Twilio/Tests/Integration/Trunking/V1/Trunk/CredentialListTest.php
+++ b/Twilio/Tests/Integration/Trunking/V1/Trunk/CredentialListTest.php
@@ -25,10 +25,10 @@ class CredentialListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -62,10 +62,10 @@ class CredentialListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CredentialLists/CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -93,12 +93,12 @@ class CredentialListTest extends HolodeckTestCase {
             'CredentialListSid' => "CLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CredentialLists',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -132,10 +132,10 @@ class CredentialListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CredentialLists'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -170,7 +170,7 @@ class CredentialListTest extends HolodeckTestCase {
         $actual = $this->twilio->trunking->v1->trunks("TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                              ->credentialsLists->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Trunking/V1/Trunk/IpAccessControlListTest.php
+++ b/Twilio/Tests/Integration/Trunking/V1/Trunk/IpAccessControlListTest.php
@@ -25,10 +25,10 @@ class IpAccessControlListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -62,10 +62,10 @@ class IpAccessControlListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAccessControlLists/ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -93,12 +93,12 @@ class IpAccessControlListTest extends HolodeckTestCase {
             'IpAccessControlListSid' => "ALaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAccessControlLists',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -132,10 +132,10 @@ class IpAccessControlListTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IpAccessControlLists'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -171,7 +171,7 @@ class IpAccessControlListTest extends HolodeckTestCase {
         $actual = $this->twilio->trunking->v1->trunks("TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                              ->ipAccessControlLists->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Trunking/V1/Trunk/OriginationUrlTest.php
+++ b/Twilio/Tests/Integration/Trunking/V1/Trunk/OriginationUrlTest.php
@@ -25,10 +25,10 @@ class OriginationUrlTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OriginationUrls/OUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -66,10 +66,10 @@ class OriginationUrlTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OriginationUrls/OUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -101,12 +101,12 @@ class OriginationUrlTest extends HolodeckTestCase {
             'SipUrl' => "https://example.com",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OriginationUrls',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -144,10 +144,10 @@ class OriginationUrlTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OriginationUrls'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -186,7 +186,7 @@ class OriginationUrlTest extends HolodeckTestCase {
         $actual = $this->twilio->trunking->v1->trunks("TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                              ->originationUrls->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -223,10 +223,10 @@ class OriginationUrlTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OriginationUrls/OUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {

--- a/Twilio/Tests/Integration/Trunking/V1/Trunk/PhoneNumberTest.php
+++ b/Twilio/Tests/Integration/Trunking/V1/Trunk/PhoneNumberTest.php
@@ -25,10 +25,10 @@ class PhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/PhoneNumbers/PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -87,10 +87,10 @@ class PhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/PhoneNumbers/PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -118,12 +118,12 @@ class PhoneNumberTest extends HolodeckTestCase {
             'PhoneNumberSid' => "PNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/PhoneNumbers',
             null,
             $values
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -182,10 +182,10 @@ class PhoneNumberTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/PhoneNumbers'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -245,7 +245,7 @@ class PhoneNumberTest extends HolodeckTestCase {
         $actual = $this->twilio->trunking->v1->trunks("TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                              ->phoneNumbers->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {

--- a/Twilio/Tests/Integration/Trunking/V1/TrunkTest.php
+++ b/Twilio/Tests/Integration/Trunking/V1/TrunkTest.php
@@ -24,10 +24,10 @@ class TrunkTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testFetchResponse() {
@@ -74,10 +74,10 @@ class TrunkTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'delete',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testDeleteResponse() {
@@ -99,10 +99,10 @@ class TrunkTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://trunking.twilio.com/v1/Trunks'
-        )));
+        ));
     }
 
     public function testCreateResponse() {
@@ -149,10 +149,10 @@ class TrunkTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'get',
             'https://trunking.twilio.com/v1/Trunks'
-        )));
+        ));
     }
 
     public function testReadFullResponse() {
@@ -201,7 +201,7 @@ class TrunkTest extends HolodeckTestCase {
         
         $actual = $this->twilio->trunking->v1->trunks->read();
         
-        $this->assertTrue(count($actual) > 0);
+        $this->assertGreaterThan(0, count($actual));
     }
 
     public function testReadEmptyResponse() {
@@ -236,10 +236,10 @@ class TrunkTest extends HolodeckTestCase {
         } catch (DeserializeException $e) {}
           catch (TwilioException $e) {}
         
-        $this->assertTrue($this->holodeck->hasRequest(new Request(
+        $this->assertRequest(new Request(
             'post',
             'https://trunking.twilio.com/v1/Trunks/TRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )));
+        ));
     }
 
     public function testUpdateResponse() {


### PR DESCRIPTION
  - URL segments are generally sids, but in the case that they are phone
     numbers or sid-likes, they should be `rawurlencode()`d
  - Updates the Holodeck assertions so they produce better failure messages.
  - Updates appropriate tests to assert correct behavior.