### PR TITLE
Fix TaskRouter Capability Tokens

### DIFF
--- a/Services/Twilio/Capability.php
+++ b/Services/Twilio/Capability.php
@@ -1,5 +1,5 @@
 <?php
-include_once 'JWT.php';
+include_once (dirname(__FILE__).'/JWT.php');
 /**
  * Twilio Capability Token generator
  *

--- a/Services/Twilio/TaskRouter/Capability.php
+++ b/Services/Twilio/TaskRouter/Capability.php
@@ -1,5 +1,5 @@
 <?php
-include_once 'CapabilityAPI.php';
+include_once (dirname(__FILE__).'/CapabilityAPI.php');
 /**
  * Twilio TaskRouter Capability assigner
  *

--- a/Services/Twilio/TaskRouter/Capability.php
+++ b/Services/Twilio/TaskRouter/Capability.php
@@ -1,5 +1,5 @@
 <?php
-
+include_once 'CapabilityAPI.php';
 /**
  * Twilio TaskRouter Capability assigner
  *

--- a/Services/Twilio/TaskRouter/CapabilityAPI.php
+++ b/Services/Twilio/TaskRouter/CapabilityAPI.php
@@ -1,4 +1,5 @@
 <?php
+include_once (dirname(__FILE__).'/../JWT.php');
 /**
  * Twilio API Capability Token generator
  *

--- a/Services/Twilio/TaskRouter/TaskQueue/Capability.php
+++ b/Services/Twilio/TaskRouter/TaskQueue/Capability.php
@@ -1,5 +1,5 @@
 <?php
-
+include_once (dirname(__FILE__).'/../Capability.php');
 /**
  * Twilio TaskRouter TaskQueue Capability assigner
  *

--- a/Services/Twilio/TaskRouter/Worker/Capability.php
+++ b/Services/Twilio/TaskRouter/Worker/Capability.php
@@ -1,5 +1,5 @@
 <?php
-
+include_once (dirname(__FILE__).'/../Capability.php');
 /**
  * Twilio TaskRouter Worker Capability assigner
  *

--- a/Services/Twilio/TaskRouter/Workspace/Capability.php
+++ b/Services/Twilio/TaskRouter/Workspace/Capability.php
@@ -1,5 +1,5 @@
 <?php
-
+include_once (dirname(__FILE__).'/../Capability.php');
 /**
  * Twilio TaskRouter Workspace Capability assigner
  *


### PR DESCRIPTION
- Readd include_once for dependencies
- Fix issue with redeclaring JWT.php due to separate directories now for TaskRouter vs. Client capability tokens.
