### PR TITLE
TwilioCollection

### DIFF
--- a/Twilio/TwilioCollection.php
+++ b/Twilio/TwilioCollection.php
@@ -4,7 +4,7 @@
 namespace Twilio;
 
 
-class TwilioCollection {
+class TwilioCollection implements \IteratorAggregate {
     protected $items;
 
     public function __construct(Array $collection) {
@@ -23,6 +23,10 @@ class TwilioCollection {
         }
 
         return $collection;
+    }
+
+    public function getIterator() {
+        return new ArrayIterator( $this->items );
     }
 
     public function __toString() {

--- a/Twilio/TwilioCollection.php
+++ b/Twilio/TwilioCollection.php
@@ -26,7 +26,7 @@ class TwilioCollection implements \IteratorAggregate {
     }
 
     public function getIterator() {
-        return new ArrayIterator( $this->items );
+        return new \ArrayIterator( $this->toArray() );
     }
 
     public function __toString() {

--- a/Twilio/TwilioCollection.php
+++ b/Twilio/TwilioCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace Twilio;
+
+
+class TwilioCollection {
+    protected $items;
+
+    public function __construct(Array $collection) {
+        $this->items    = $collection;
+    }
+
+    public function toArray()
+    {
+        $collection = array();
+        foreach($this->items as $item) {
+            if ($item instanceof InstanceResource) {
+                array_push($collection, $item->toArray());
+            } else {
+                array_push($collection, $item);
+            }
+        }
+
+        return $collection;
+    }
+
+    public function __toString() {
+        return '[TwilioCollection]';
+    }
+}


### PR DESCRIPTION
Accepts an `array()` to create a `TwilioCollection`.

Has the ability to call `toArray()` on the `TwilioCollection`. This will iterate any children that are an instance of `InstanceResource` and call the method `toArray()` to flatten the collection. #381 

If not an instance of `InstanceResource` it will just push to the collection items regardless.
