### PR TITLE
Add incoming.allow to AccessToken VoiceGrant

### DIFF
--- a/Twilio/Jwt/Grants/VoiceGrant.php
+++ b/Twilio/Jwt/Grants/VoiceGrant.php
@@ -6,10 +6,34 @@ namespace Twilio\Jwt\Grants;
 
 class VoiceGrant implements Grant {
 
+    private $incomingAllow;
     private $outgoingApplicationSid;
     private $outgoingApplicationParams;
     private $pushCredentialSid;
     private $endpointId;
+
+    /**
+     * Returns whether incoming is allowed
+     *
+     * @return boolean whether incoming is allowed
+     */
+    public function getIncomingAllow()
+    {
+        return $this->incomingAllow;
+    }
+
+    /**
+     * Set whether incoming is allowed
+     *
+     * @param boolean $incomingAllow whether incoming is allowed
+     *
+     * @return $this updated grant
+     */
+    public function setIncomingAllow($incomingAllow)
+    {
+        $this->incomingAllow = $incomingAllow;
+        return $this;
+    }
 
     /**
      * Returns the outgoing application sid
@@ -122,6 +146,12 @@ class VoiceGrant implements Grant {
     public function getPayload()
     {
         $payload = array();
+        if ($this->incomingAllow == true) {
+            $incoming = array();
+            $incoming['allow'] = true;
+            $payload['incoming'] = $incoming;
+        }
+
         if ($this->outgoingApplicationSid) {
             $outgoing = array();
             $outgoing['application_sid'] = $this->outgoingApplicationSid;

--- a/Twilio/Tests/Unit/Jwt/AccessTokenTest.php
+++ b/Twilio/Tests/Unit/Jwt/AccessTokenTest.php
@@ -159,6 +159,7 @@ class AccessTokenTest extends UnitTest {
         $scat->setIdentity('test identity');
 
         $pvg = new VoiceGrant();
+        $pvg->setIncomingAllow(true);
         $pvg->setOutgoingApplication('AP123', array('foo' => 'bar'));
 
         $scat->addGrant($pvg);
@@ -174,6 +175,9 @@ class AccessTokenTest extends UnitTest {
         $this->assertEquals('test identity', $payload->grants->identity);
 
         $decodedGrant = $grants['voice'];
+        $incoming = $decodedGrant['incoming'];
+        $this->assertEquals(true, $incoming['allow']);
+
         $outgoing = $decodedGrant['outgoing'];
         $this->assertEquals('AP123', $outgoing['application_sid']);
 


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/CLIENT-4492

To support JS Clients per this spec:
https://paper.dropbox.com/doc/Proposal-FPA-Token-Format-for-Programmable-Voice-SDKs-xhdFHD6N3aPW9GRp4dXNX