### PR TITLE
Ability to specify custom claims when creating ClientToken

### DIFF
--- a/Twilio/Jwt/AccessToken.php
+++ b/Twilio/Jwt/AccessToken.php
@@ -14,6 +14,8 @@ class AccessToken {
     private $nbf;
     /** @var Grant[] $grants */
     private $grants;
+    /** @var string[] $customClaims */
+    private $customClaims;
 
     public function __construct($accountSid, $signingKeySid, $secret, $ttl = 3600, $identity = null) {
         $this->signingKeySid = $signingKeySid;
@@ -26,6 +28,7 @@ class AccessToken {
         }
 
         $this->grants = array();
+        $this->customClaims = array();
     }
 
     /**
@@ -82,6 +85,15 @@ class AccessToken {
         return $this;
     }
 
+    /**
+     * Allows to set custom claims, which then will be encoded into JWT payload.
+     *
+     * @param string $name
+     * @param string $value
+     */
+    public function addClaim($name, $value) {
+        $this->customClaims[$name] = $value;
+    }
 
     public function toJWT($algorithm = 'HS256') {
         $header = array(
@@ -109,13 +121,13 @@ class AccessToken {
             $grants = json_decode('{}');
         }
 
-        $payload = array(
+        $payload = array_merge($this->customClaims, array(
             'jti' => $this->signingKeySid . '-' . $now,
             'iss' => $this->signingKeySid,
             'sub' => $this->accountSid,
             'exp' => $now + $this->ttl,
             'grants' => $grants
-        );
+        ));
 
         if (!is_null($this->nbf)) {
             $payload['nbf'] = $this->nbf;

--- a/Twilio/Jwt/ClientToken.php
+++ b/Twilio/Jwt/ClientToken.php
@@ -13,6 +13,8 @@ class ClientToken {
     public $authToken;
     /** @var ScopeURI[] $scopes */
     public $scopes;
+    /** @var string[] $customClaims */
+    private $customClaims;
 
     /**
      * Create a new TwilioCapability with zero permissions. Next steps are to
@@ -29,6 +31,7 @@ class ClientToken {
         $this->authToken = $authToken;
         $this->scopes = array();
         $this->clientName = false;
+        $this->customClaims = array();
     }
 
     /**
@@ -83,6 +86,16 @@ class ClientToken {
     }
 
     /**
+     * Allows to set custom claims, which then will be encoded into JWT payload.
+     *
+     * @param string $name
+     * @param string $value
+     */
+    public function addClaim($name, $value) {
+        $this->customClaims[$name] = $value;
+    }
+
+    /**
      * Generates a new token based on the credentials and permissions that
      * previously has been granted to this token.
      *
@@ -92,11 +105,11 @@ class ClientToken {
      *         seconds
      */
     public function generateToken($ttl = 3600) {
-        $payload = array(
+        $payload = array_merge($this->customClaims, array(
             'scope' => array(),
             'iss' => $this->accountSid,
             'exp' => time() + $ttl,
-        );
+        ));
         $scopeStrings = array();
 
         foreach ($this->scopes as $scope) {

--- a/Twilio/Tests/Unit/Jwt/AccessTokenTest.php
+++ b/Twilio/Tests/Unit/Jwt/AccessTokenTest.php
@@ -202,4 +202,13 @@ class AccessTokenTest extends UnitTest {
         $this->assertEquals("worker", $grants['task_router']['role']);
     }
 
+    public function testCustomClaims() {
+        $scat = new AccessToken(self::ACCOUNT_SID, self::SIGNING_KEY_SID, 'secret');
+        $scat->addClaim('find', 'me');
+        $scat->addClaim('sub', 'redefined');
+        $payload = JWT::decode($scat->toJWT(), 'secret');
+        $this->assertSame('me', $payload->find);
+        $this->assertNotSame('redefined', $payload->sub);
+    }
+
 }

--- a/Twilio/Tests/Unit/Jwt/ClientTokenTest.php
+++ b/Twilio/Tests/Unit/Jwt/ClientTokenTest.php
@@ -62,6 +62,13 @@ class ClientTokenTest extends UnitTest {
         $this->assertEquals($payload->scope, $event_uri);
     }
 
+    public function testCustomClaims() {
+        $token = new ClientToken('AC123', 'foo');
+        $token->addClaim('find', 'me');
+        $payload = JWT::decode($token->generateToken(), 'foo');
+        $this->assertEquals('me', $payload->find);
+    }
+
 
     public function testDecode() {
         $token = new ClientToken('AC123', 'foo');

--- a/Twilio/Tests/Unit/Jwt/ClientTokenTest.php
+++ b/Twilio/Tests/Unit/Jwt/ClientTokenTest.php
@@ -65,8 +65,10 @@ class ClientTokenTest extends UnitTest {
     public function testCustomClaims() {
         $token = new ClientToken('AC123', 'foo');
         $token->addClaim('find', 'me');
+        $token->addClaim('iss', 'redefined');
         $payload = JWT::decode($token->generateToken(), 'foo');
-        $this->assertEquals('me', $payload->find);
+        $this->assertSame('me', $payload->find);
+        $this->assertNotSame('redefined', $payload->iss);
     }
 
 


### PR DESCRIPTION
Hi there.

I'm developing phone application and want to use the same JWT token across Twilio and my web API. In the current implementation, there is no ability to specify any custom claims.

Now I'm using my fork and it works fine:

```php
$tokenGenerator = Yii::$app->twilio->createClientToken();
$tokenGenerator->allowClientOutgoing(Yii::$app->params['twilio']['appSid']);
$tokenGenerator->addClaim('api-user', 'phone|' . $user->id);

return $tokenGenerator->generateToken();
```

I will be glad to see this functionality in the library.