### PR TITLE
Added @throws PHPDoc tags to Sync API Context and Version classes

### DIFF
--- a/Twilio/Rest/Sync/V1/Service/DocumentContext.php
+++ b/Twilio/Rest/Sync/V1/Service/DocumentContext.php
@@ -47,6 +47,7 @@ class DocumentContext extends InstanceContext {
      * Fetch a DocumentInstance
      * 
      * @return DocumentInstance Fetched DocumentInstance
+     * @throws TwilioException
      */
     public function fetch() {
         $params = Values::of(array());
@@ -69,6 +70,7 @@ class DocumentContext extends InstanceContext {
      * Deletes the DocumentInstance
      * 
      * @return boolean True if delete succeeds, false otherwise
+     * @throws TwilioException
      */
     public function delete() {
         return $this->version->delete('delete', $this->uri);
@@ -79,6 +81,7 @@ class DocumentContext extends InstanceContext {
      * 
      * @param array|Options $options Optional Arguments
      * @return DocumentInstance Updated DocumentInstance
+     * @throws TwilioException
      */
     public function update($options = array()) {
         $options = new Values($options);

--- a/Twilio/Rest/Sync/V1/Service/SyncListContext.php
+++ b/Twilio/Rest/Sync/V1/Service/SyncListContext.php
@@ -50,6 +50,7 @@ class SyncListContext extends InstanceContext {
      * Fetch a SyncListInstance
      * 
      * @return SyncListInstance Fetched SyncListInstance
+     * @throws TwilioException
      */
     public function fetch() {
         $params = Values::of(array());
@@ -72,6 +73,7 @@ class SyncListContext extends InstanceContext {
      * Deletes the SyncListInstance
      * 
      * @return boolean True if delete succeeds, false otherwise
+     * @throws TwilioException
      */
     public function delete() {
         return $this->version->delete('delete', $this->uri);
@@ -82,6 +84,7 @@ class SyncListContext extends InstanceContext {
      * 
      * @param array|Options $options Optional Arguments
      * @return SyncListInstance Updated SyncListInstance
+     * @throws TwilioException
      */
     public function update($options = array()) {
         $options = new Values($options);

--- a/Twilio/Rest/Sync/V1/Service/SyncMap/SyncMapItemContext.php
+++ b/Twilio/Rest/Sync/V1/Service/SyncMap/SyncMapItemContext.php
@@ -9,6 +9,7 @@
 
 namespace Twilio\Rest\Sync\V1\Service\SyncMap;
 
+use Twilio\Exceptions\TwilioException;
 use Twilio\InstanceContext;
 use Twilio\Options;
 use Twilio\Serialize;
@@ -41,6 +42,7 @@ class SyncMapItemContext extends InstanceContext {
      * Fetch a SyncMapItemInstance
      * 
      * @return SyncMapItemInstance Fetched SyncMapItemInstance
+     * @throws TwilioException
      */
     public function fetch() {
         $params = Values::of(array());
@@ -64,6 +66,7 @@ class SyncMapItemContext extends InstanceContext {
      * Deletes the SyncMapItemInstance
      * 
      * @return boolean True if delete succeeds, false otherwise
+     * @throws TwilioException
      */
     public function delete() {
         return $this->version->delete('delete', $this->uri);
@@ -74,6 +77,7 @@ class SyncMapItemContext extends InstanceContext {
      * 
      * @param array|Options $options Optional Arguments
      * @return SyncMapItemInstance Updated SyncMapItemInstance
+     * @throws TwilioException
      */
     public function update($options = array()) {
         $options = new Values($options);

--- a/Twilio/Rest/Sync/V1/Service/SyncMapContext.php
+++ b/Twilio/Rest/Sync/V1/Service/SyncMapContext.php
@@ -35,7 +35,7 @@ class SyncMapContext extends InstanceContext {
      * @param \Twilio\Version $version Version that contains the resource
      * @param string $serviceSid The service_sid
      * @param string $sid The sid
-     * @return \Twilio\Rest\Sync\V1\Service\SyncMapContext 
+     * @return \Twilio\Rest\Sync\V1\Service\SyncMapContext
      */
     public function __construct(Version $version, $serviceSid, $sid) {
         parent::__construct($version);
@@ -48,8 +48,9 @@ class SyncMapContext extends InstanceContext {
 
     /**
      * Fetch a SyncMapInstance
-     * 
+     *
      * @return SyncMapInstance Fetched SyncMapInstance
+     * @throws TwilioException
      */
     public function fetch() {
         $params = Values::of(array());
@@ -72,6 +73,7 @@ class SyncMapContext extends InstanceContext {
      * Deletes the SyncMapInstance
      * 
      * @return boolean True if delete succeeds, false otherwise
+     * @throws TwilioException
      */
     public function delete() {
         return $this->version->delete('delete', $this->uri);
@@ -82,6 +84,7 @@ class SyncMapContext extends InstanceContext {
      * 
      * @param array|Options $options Optional Arguments
      * @return SyncMapInstance Updated SyncMapInstance
+     * @throws TwilioException
      */
     public function update($options = array()) {
         $options = new Values($options);

--- a/Twilio/Rest/Sync/V1/Service/SyncStreamContext.php
+++ b/Twilio/Rest/Sync/V1/Service/SyncStreamContext.php
@@ -45,6 +45,7 @@ class SyncStreamContext extends InstanceContext {
      * Fetch a SyncStreamInstance
      * 
      * @return SyncStreamInstance Fetched SyncStreamInstance
+     * @throws TwilioException
      */
     public function fetch() {
         $params = Values::of(array());
@@ -67,6 +68,7 @@ class SyncStreamContext extends InstanceContext {
      * Deletes the SyncStreamInstance
      * 
      * @return boolean True if delete succeeds, false otherwise
+     * @throws TwilioException
      */
     public function delete() {
         return $this->version->delete('delete', $this->uri);
@@ -77,6 +79,7 @@ class SyncStreamContext extends InstanceContext {
      * 
      * @param array|Options $options Optional Arguments
      * @return SyncStreamInstance Updated SyncStreamInstance
+     * @throws TwilioException
      */
     public function update($options = array()) {
         $options = new Values($options);

--- a/Twilio/Version.php
+++ b/Twilio/Version.php
@@ -88,6 +88,9 @@ abstract class Version {
         }
     }
 
+    /**
+     * @throws TwilioException
+     */
     public function fetch($method, $uri, $params = array(), $data = array(),
                           $headers = array(), $username = null,
                           $password = null, $timeout = null) {
@@ -109,6 +112,9 @@ abstract class Version {
         return $response->getContent();
     }
 
+    /**
+     * @throws TwilioException
+     */
     public function update($method, $uri, $params = array(), $data = array(),
                            $headers = array(), $username = null,
                            $password = null, $timeout = null) {
@@ -130,6 +136,9 @@ abstract class Version {
         return $response->getContent();
     }
 
+    /**
+     * @throws TwilioException
+     */
     public function delete($method, $uri, $params = array(), $data = array(),
                            $headers = array(), $username = null,
                            $password = null, $timeout = null) {
@@ -189,6 +198,9 @@ abstract class Version {
         return new Stream($page, $limit, $pageLimit);
     }
 
+    /**
+     * @throws TwilioException
+     */
     public function create($method, $uri, $params = array(), $data = array(),
                            $headers = array(), $username = null,
                            $password = null, $timeout = null) {


### PR DESCRIPTION
Hi there,

We have been actively integrating the Twilio API to our PHP structure in our company, and recently  startied to handling errors more efficiently for each of the services offered from the Rest client. However, an issue came up where the `TwilioException` thrown from the Twilio Sync Context was not being detected from our end.

This branch's purpose is to ensure all endpoints have the `@throws` PHP doc block in the functions where the `exception` function is referenced. The IDEs will then correctly spot the user of the `TwilioException` within the package code.