### PR TITLE
Add method to validate ssl certificate

### DIFF
--- a/Twilio/Rest/Client.php
+++ b/Twilio/Rest/Client.php
@@ -825,7 +825,7 @@ class Client {
         return '[Client ' . $this->getAccountSid() . ']';
     }
 
-     /**
+	 /**
 	  * Validates connection to new SSL certificate endpoint
 	  *
 	  * @param CurlClient $client

--- a/Twilio/Rest/Client.php
+++ b/Twilio/Rest/Client.php
@@ -10,7 +10,6 @@
 namespace Twilio\Rest;
 
 use Twilio\Exceptions\ConfigurationException;
-use Twilio\Exceptions\RestException;
 use Twilio\Exceptions\TwilioException;
 use Twilio\Http\Client as HttpClient;
 use Twilio\Http\CurlClient;
@@ -830,12 +829,13 @@ class Client {
 	  * Validates connection to new SSL certificate endpoint
 	  *
 	  * @param CurlClient $client
-	  * @throws RestException if request fails
+	  * @throws TwilioException if request fails
 	  */
 	public function validateSslCertificate($client) {
 		$response = $client->request('GET', 'https://api.twilio.com:8443');
+
 		if ($response->getStatusCode() < 200 || $response->getStatusCode() > 300) {
-			throw new RestException("Failed to validate SSL certificate", $response->getStatusCode(), $response->getStatusCode());
+			throw new TwilioException("Failed to validate SSL certificate");
 		}
 	}
 

--- a/Twilio/Rest/Client.php
+++ b/Twilio/Rest/Client.php
@@ -10,6 +10,7 @@
 namespace Twilio\Rest;
 
 use Twilio\Exceptions\ConfigurationException;
+use Twilio\Exceptions\RestException;
 use Twilio\Exceptions\TwilioException;
 use Twilio\Http\Client as HttpClient;
 use Twilio\Http\CurlClient;
@@ -824,4 +825,18 @@ class Client {
     public function __toString() {
         return '[Client ' . $this->getAccountSid() . ']';
     }
+
+     /**
+	  * Validates connection to new SSL certificate endpoint
+	  *
+	  * @param CurlClient $client
+	  * @throws RestException if request fails
+	  */
+	public function validateSslCertificate($client) {
+		$response = $client->request('GET', 'https://api.twilio.com:8443');
+		if ($response->getStatusCode() < 200 || $response->getStatusCode() > 300) {
+			throw new RestException("Failed to validate SSL certificate", $response->getStatusCode(), $response->getStatusCode());
+		}
+	}
+
 }

--- a/Twilio/Tests/Unit/Rest/ClientTest.php
+++ b/Twilio/Tests/Unit/Rest/ClientTest.php
@@ -3,7 +3,8 @@
 
 namespace Twilio\Tests\Unit\Rest;
 
-
+use Twilio\Http\CurlClient;
+use Twilio\Http\Response;
 use Twilio\Rest\Client;
 use Twilio\Tests\Holodeck;
 use Twilio\Tests\Request;
@@ -109,5 +110,26 @@ class ClientTest extends UnitTest {
         $expected = new Request('POST', 'https://test.ie1.twilio.com/v1/Resources');
         $this->assertTrue($network->hasRequest($expected));
     }
+
+	public function testValidationSslCertificateSuccess() {
+		$client = new Client('username', 'password');
+		$curlClient = $this->getMock(CurlClient::class);
+		$curlClient->method('request')
+			->willReturn(new Response(200, ''));
+
+		$client->validateSslCertificate($curlClient);
+	}
+
+	/**
+	 * @expectedException \Twilio\Exceptions\RestException
+	 */
+	public function testValidationSslCertificateError() {
+		$client = new Client('username', 'password');
+		$curlClient = $this->getMock(CurlClient::class);
+		$curlClient->method('request')
+			->willReturn(new Response(504, ''));
+
+		$client->validateSslCertificate($curlClient);
+	}
 
 }

--- a/Twilio/Tests/Unit/Rest/ClientTest.php
+++ b/Twilio/Tests/Unit/Rest/ClientTest.php
@@ -121,14 +121,14 @@ class ClientTest extends UnitTest {
 	}
 
 	/**
-	 * @expectedException \Twilio\Exceptions\RestException
+	 * @expectedException \Twilio\Exceptions\TwilioException
 	 */
 	public function testValidationSslCertificateError() {
 		$client = new Client('username', 'password');
 		$curlClient = $this->getMock(CurlClient::class);
 		$curlClient->method('request')
 			->willReturn(new Response(504, ''));
-
+		
 		$client->validateSslCertificate($curlClient);
 	}
 


### PR DESCRIPTION
Add `validateSslCertificate` to check whether we can successfully make requests to the endpoint that uses the new SSL certificate

Note: `Client.php` is auto-generated; there'll be a separate PR for generating the new code.