### PR TITLE
Allow adding TwiML children with generic tag names

### DIFF
--- a/Twilio/Tests/Unit/TwiML/FaxResponseTest.php
+++ b/Twilio/Tests/Unit/TwiML/FaxResponseTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Twilio\Tests\Unit\TwiML;
+
+use DOMDocument;
+use Twilio\Tests\Unit\UnitTest;
+use Twilio\TwiML\FaxResponse;
+
+class FaxResponseTest extends UnitTest {
+
+	public function compareXml($expected, $result) {
+		$expectedDom = new DOMDocument();
+		$expectedDom->loadXML($expected);
+
+		$resultDom = new DOMDocument();
+		$resultDom->loadXML($result);
+
+		$this->assertEquals($expectedDom, $resultDom);
+	}
+
+	public function testTextNode() {
+		$response = new FaxResponse();
+		$response->append('Hey no tags!');
+
+		$this->compareXml('<Response>Hey no tags!</Response>', $response);
+	}
+
+	public function testMixedText() {
+		$response = new FaxResponse();
+		$response->append('before');
+
+		$response->receive('Content')
+			->setAttribute('key', 'value');
+
+		$response->append('after');
+
+		$this->compareXml('<Response>before<Receive key="value">Content</Receive>after</Response>', $response);
+	}
+
+	public function testEmptyResponse() {
+		$this->compareXml('<Response/>', new FaxResponse());
+	}
+
+	public function testAllowGenericChildNodes() {
+		$response = new FaxResponse();
+		$response->addChild('generic-node', 'Generic Node', ['tag' => true]);
+
+		$this->compareXml('<Response><generic-node tag="true">Generic Node</generic-node></Response>', $response);
+	}
+
+	public function testAllowGenericChildrenOfChildNodes() {
+		$response = new FaxResponse();
+		$response->receive('Content')
+			->setAttribute('key', 'value')
+			->addChild('generic-node', 'Generic Node', ['tag' => true]);
+
+		$this->compareXml('<Response><Receive key="value">Content<generic-node tag="true">Generic Node</generic-node></Receive></Response>', $response);
+	}
+}

--- a/Twilio/Tests/Unit/TwiML/MessagingResponseTest.php
+++ b/Twilio/Tests/Unit/TwiML/MessagingResponseTest.php
@@ -40,4 +40,20 @@ class MessagingResponseTest extends UnitTest {
     public function testEmptyResponse() {
         $this->compareXml('<Response/>', new MessagingResponse());
     }
+
+	public function testAllowGenericChildNodes() {
+		$response = new MessagingResponse();
+		$response->addChild('generic-node', 'Generic Node', ['tag' => true]);
+
+		$this->compareXml('<Response><generic-node tag="true">Generic Node</generic-node></Response>', $response);
+	}
+
+	public function testAllowGenericChildrenOfChildNodes() {
+		$response = new MessagingResponse();
+		$response->message('Content')
+			->setAttribute('key', 'value')
+			->addChild('generic-node', 'Generic Node', ['tag' => true]);
+
+		$this->compareXml('<Response><Message key="value">Content<generic-node tag="true">Generic Node</generic-node></Message></Response>', $response);
+	}
 }

--- a/Twilio/Tests/Unit/TwiML/VoiceResponseTest.php
+++ b/Twilio/Tests/Unit/TwiML/VoiceResponseTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Twilio\Tests\Unit\TwiML;
+
+use DOMDocument;
+use Twilio\Tests\Unit\UnitTest;
+use Twilio\TwiML\VoiceResponse;
+
+class VoiceResponseTest extends UnitTest {
+
+	public function compareXml($expected, $result) {
+		$expectedDom = new DOMDocument();
+		$expectedDom->loadXML($expected);
+
+		$resultDom = new DOMDocument();
+		$resultDom->loadXML($result);
+
+		$this->assertEquals($expectedDom, $resultDom);
+	}
+
+	public function testTextNode() {
+		$response = new VoiceResponse();
+		$response->append('Hey no tags!');
+
+		$this->compareXml('<Response>Hey no tags!</Response>', $response);
+	}
+
+	public function testMixedText() {
+		$response = new VoiceResponse();
+		$response->append('before');
+
+		$response->dial('Content')
+			->setAttribute('key', 'value');
+
+		$response->append('after');
+
+		$this->compareXml('<Response>before<Dial key="value">Content</Dial>after</Response>', $response);
+	}
+
+	public function testEmptyResponse() {
+		$this->compareXml('<Response/>', new VoiceResponse());
+	}
+
+	public function testAllowGenericChildNodes() {
+		$response = new VoiceResponse();
+		$response->addChild('generic-node', 'Generic Node', ['tag' => true]);
+
+		$this->compareXml('<Response><generic-node tag="true">Generic Node</generic-node></Response>', $response);
+	}
+
+	public function testAllowGenericChildrenOfChildNodes() {
+		$response = new VoiceResponse();
+		$response->dial('Content')
+			->setAttribute('key', 'value')
+			->addChild('generic-node', 'Generic Node', ['tag' => true]);
+
+		$this->compareXml('<Response><Dial key="value">Content<generic-node tag="true">Generic Node</generic-node></Dial></Response>', $response);
+	}
+}

--- a/Twilio/TwiML/GenericNode.php
+++ b/Twilio/TwiML/GenericNode.php
@@ -11,7 +11,7 @@ class GenericNode extends TwiML {
 	 * @param string $value XML value
 	 * @param array $attributes XML attributes
 	 */
-	public function __construct($name, $value = null, $attributes = array()) {
+	public function __construct($name, $value, $attributes) {
 		parent::__construct($name, $value, $attributes);
 		$this->name = $name;
 		$this->value = $value;

--- a/Twilio/TwiML/GenericNode.php
+++ b/Twilio/TwiML/GenericNode.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Twilio\TwiML;
+
+class GenericNode extends TwiML {
+
+	/**
+	 * GenericNode constructor.
+	 *
+	 * @param string $name XML element name
+	 * @param string $value XML value
+	 * @param array $attributes XML attributes
+	 */
+	public function __construct($name, $value = null, $attributes = array()) {
+		parent::__construct($name, $value, $attributes);
+		$this->name = $name;
+		$this->value = $value;
+	}}

--- a/Twilio/TwiML/TwiML.php
+++ b/Twilio/TwiML/TwiML.php
@@ -67,6 +67,19 @@ abstract class TwiML {
         return $this;
     }
 
+	/**
+	 * @param string $name XML element name
+	 * @param string $value XML value
+	 * @param array $attributes XML attributes
+	 */
+	public function addChild($name, $value = null, $attributes) {
+		$this->nest(new GenericNode($name, $value, $attributes));
+	}
+
+	public function addText($text) {
+		return $this->value = $text;
+	}
+
     /**
      * Convert TwiML to XML string.
      * 
@@ -90,6 +103,7 @@ abstract class TwiML {
      * 
      * @param TwiML $twiml TwiML element to convert to XML
      * @param DOMDocument $document XML document for the element
+     * @return DOMElement $element
      */
     private function buildElement($twiml, $document) {
     	$element = $document->createElement($twiml->name);
@@ -122,4 +136,5 @@ abstract class TwiML {
     	$document->appendChild($this->buildElement($this, $document));
     	return $document;
     }
+
 }

--- a/Twilio/TwiML/TwiML.php
+++ b/Twilio/TwiML/TwiML.php
@@ -23,10 +23,10 @@ abstract class TwiML {
      * @param string $value XML value
      * @param array $attributes XML attributes
      */
-    public function __construct($name, $value = null, $attributes = array()) {
+    public function __construct($name, $value = null, $attributes = []) {
         $this->name = $name;
         $this->attributes = $attributes;
-        $this->children = array();
+        $this->children = [];
 
         if ($value !== null) {
         	$this->children[] = $value;
@@ -72,7 +72,7 @@ abstract class TwiML {
 	 * @param string $value XML value
 	 * @param array $attributes XML attributes
 	 */
-	public function addChild($name, $value = null, $attributes) {
+	public function addChild($name, $value = null, $attributes = []) {
 		$this->append(new GenericNode($name, $value, $attributes));
 	}
 

--- a/Twilio/TwiML/TwiML.php
+++ b/Twilio/TwiML/TwiML.php
@@ -73,7 +73,7 @@ abstract class TwiML {
 	 * @param array $attributes XML attributes
 	 */
 	public function addChild($name, $value = null, $attributes) {
-		$this->nest(new GenericNode($name, $value, $attributes));
+		$this->append(new GenericNode($name, $value, $attributes));
 	}
 
 	public function addText($text) {


### PR DESCRIPTION
- Allow generic name for TwiML nodes
- Add tests for `MessagingResponse`, `VoiceResponse` and `FaxResponse`