### PR TITLE
Add Dockerfile and related changes to build the Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: nightly
+deploy:
+  script:
+    - make docker-build
+    - make docker-push
+  on: tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ php:
     - '7.1'
     - hhvm # on Trusty only
     - nightly
+services:
+  - docker
 script: "make test"
 before_install: "composer install --dev"
 matrix:
@@ -15,7 +17,9 @@ matrix:
     allow_failures:
         - php: nightly
 deploy:
-  script:
-    - make docker-build
-    - make docker-push
-  on: tags
+  provider: script
+  script: make docker-build && make docker-push
+  skip_cleanup: true
+  on:
+    tags: true
+    php: "5.6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:5.6
+
+RUN mkdir /twilio
+WORKDIR /twilio
+
+COPY Twilio ./Twilio
+COPY Services ./Services
+COPY composer* ./
+
+RUN curl --silent --show-error https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+RUN composer install --no-dev

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cu
 docker-build:
 	docker build -t twilio/twilio-php .
 	docker tag twilio/twilio-php twilio/twilio-php:${TRAVIS_TAG}
-	docker tag twilio/twilio-php twilio/twilio-php:${API_DEFINITIONS_SHA}
+	docker tag twilio/twilio-php twilio/twilio-php:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
 	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
 	docker push twilio/twilio-php:${TRAVIS_TAG}
-	docker push twilio/twilio-php:${API_DEFINITIONS_TAG}
+	docker push twilio/twilio-php:apidefs-${API_DEFINITIONS_TAG}
 
 .PHONY: all clean test docs docs-install test-install authors

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,15 @@ authors:
 	echo "Authors\n=======\n\nA huge thanks to all of our contributors:\n\n" > AUTHORS.md
 	git log --raw | grep "^Author: " | cut -d ' ' -f2- | cut -d '<' -f1 | sed 's/^/- /' | sort | uniq >> AUTHORS.md
 
+API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cut -d ' ' -f 5)
+docker-build:
+	docker build -t twilio/twilio-php .
+	docker tag twilio/twilio-php twilio/twilio-php:${TRAVIS_TAG}
+	docker tag twilio/twilio-php twilio/twilio-php:${API_DEFINITIONS_SHA}
+
+docker-push:
+	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+	docker push twilio/twilio-php:${TRAVIS_TAG}
+	docker push twilio/twilio-php:${API_DEFINITIONS_TAG}
+
 .PHONY: all clean test docs docs-install test-install authors

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ docker-build:
 	docker tag twilio/twilio-php twilio/twilio-php:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
-	echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+	echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 	docker push twilio/twilio-php:${TRAVIS_TAG}
 	docker push twilio/twilio-php:apidefs-${API_DEFINITIONS_SHA}
 

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ docker-build:
 	docker tag twilio/twilio-php twilio/twilio-php:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
-	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+	echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 	docker push twilio/twilio-php:${TRAVIS_TAG}
-	docker push twilio/twilio-php:apidefs-${API_DEFINITIONS_TAG}
+	docker push twilio/twilio-php:apidefs-${API_DEFINITIONS_SHA}
 
 .PHONY: all clean test docs docs-install test-install authors

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ The PHP library documentation can be found [here][documentation].
 * PHP >= 5.5
 * The PHP JSON extension
 
+## Docker Image
+
+The `Dockerfile` present in this repository and its respective `twilio/twilio-php` Docker image are currently used by Twilio for testing purposes only.
+
 # Getting help
 
 If you need help installing or using the library, please contact Twilio Support at help@twilio.com first. Twilio's Support staff are well-versed in all of the Twilio Helper Libraries, and usually reply within 24 hours.


### PR DESCRIPTION
Hi there!

This PR adds the Dockerfile and related files to build the lib Docker image. This image will be used mainly by Tricorder to generate further Tricorder worker images with the specific lib version.

The tags used in the Docker images are the version (from the release tag) and the api-definitions SHA from the release.

TODO:

- [ ] Add Docker Hub credentials to the TravisCI env
- [ ] Merge and create a release for testing