### PR TITLE
Fixes for adding child nodes / text

### DIFF
--- a/Twilio/Tests/Unit/TwiML/MessagingResponseTest.php
+++ b/Twilio/Tests/Unit/TwiML/MessagingResponseTest.php
@@ -56,4 +56,14 @@ class MessagingResponseTest extends UnitTest {
 
 		$this->compareXml('<Response><Message key="value">Content<generic-node tag="true">Generic Node</generic-node></Message></Response>', $response);
 	}
+
+	public function testGenericMixedText() {
+        $response = new MessagingResponse();
+        $response->append('before')
+            ->addChild('Child')->append('content');
+
+        $response->append('after');
+
+        $this->compareXml('<Response>before<Child>content</Child>after</Response>', $response);
+    }
 }

--- a/Twilio/TwiML/TwiML.php
+++ b/Twilio/TwiML/TwiML.php
@@ -73,11 +73,7 @@ abstract class TwiML {
 	 * @param array $attributes XML attributes
 	 */
 	public function addChild($name, $value = null, $attributes = []) {
-		$this->append(new GenericNode($name, $value, $attributes));
-	}
-
-	public function addText($text) {
-		return $this->value = $text;
+		return $this->nest(new GenericNode($name, $value, $attributes));
 	}
 
     /**


### PR DESCRIPTION
Added a test for mixed content, which uncovered a couple of related problems:

- There is no way to access generic nodes to add more children -- fixed the return value for `addChild`.
- The `addText` method is duplicative -- removed it. (This is technically a breaking change -- what do you all think?)