### PR TITLE
Added workerSid option to ReservationList Subresource Filter

### DIFF
--- a/Twilio/Rest/Taskrouter/V1/Workspace/Task/ReservationList.php
+++ b/Twilio/Rest/Taskrouter/V1/Workspace/Task/ReservationList.php
@@ -93,6 +93,7 @@ class ReservationList extends ListResource {
     public function page($options = array(), $pageSize = Values::NONE, $pageToken = Values::NONE, $pageNumber = Values::NONE) {
         $options = new Values($options);
         $params = Values::of(array(
+            'WorkerSid' => $options['workerSid'],
             'ReservationStatus' => $options['reservationStatus'],
             'PageToken' => $pageToken,
             'Page' => $pageNumber,


### PR DESCRIPTION
Hi there! This PR's purpose is to add the missing `WorkerSid` parameter for Reservation List Subresource, as shown in the following Documentation: https://www.twilio.com/docs/taskrouter/api/reservations#reservations-list-resource

The PHP's option array accepts a `workerSid` parameter in camel case to match the convention across the rest of the API Client.

Important to note that while the documentation mentions this parameter to be present in the request, it does not seem like the Filter is being used at the API level at all. Regardless of the information sent under `WorkerSid` parameter, The TaskRouter API will not return reservations specific to the worker specified. So either the Filter must be taken into account or a modification of the documentation needs an update on what filters the Reservation sub-resource does accept.

Many thanks for this awesome product!