### PR TITLE
Add deprecation warning to the old Twiml class

### DIFF
--- a/Twilio/Twiml.php
+++ b/Twilio/Twiml.php
@@ -6,6 +6,7 @@ use Twilio\Exceptions\TwimlException;
 
 /**
  * Twiml response generator.
+ * @deprecated Use the generated types in the Twilio\TwiML namespace instead
  */
 class Twiml {
 


### PR DESCRIPTION
Steer folks towards the new `Twilio\TwiML` classes instead of `Twilio\Twiml`.