### PR TITLE
Pin hhvm to pre-4.0 because of lack of composer support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
     - '5.6'
     - '7.0'
     - '7.1'
-    - hhvm-3.30.3 # on Trusty only
+    - hhvm-3.30.3-1 # on Trusty only
     - nightly
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
     - '5.6'
     - '7.0'
     - '7.1'
-    - hhvm # on Trusty only
+    - hhvm-3.30.3 # on Trusty only
     - nightly
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
     - '5.6'
     - '7.0'
     - '7.1'
-    - hhvm-3.30.3-1 # on Trusty only
+    - hhvm-3.18 # on Trusty only
     - nightly
 services:
   - docker


### PR DESCRIPTION
Pin hhvm to 3.x because 4.x no longer supports composer.

We will need to follow developments here on hhvm if they introduce a new package manager and add support for that.