### PR TITLE
GuzzleClient - fix body retrieval to rewind

### DIFF
--- a/Twilio/Http/GuzzleClient.php
+++ b/Twilio/Http/GuzzleClient.php
@@ -44,6 +44,6 @@ final class GuzzleClient implements Client
             throw new HttpException('Unable to complete the HTTP request', 0, $exception);
         }
 
-        return new Response($response->getStatusCode(), $response->getBody()->getContents(), $response->getHeaders());
+        return new Response($response->getStatusCode(), "" . $response->getBody(), $response->getHeaders());
     }
 }


### PR DESCRIPTION
Logging (or other) middleware may have already read from the Guzzle body - getContents() only returns remaining contents from the stream. 

We definitely want it all, so cast to a string (which forces a rewind) 

See also: https://stackoverflow.com/a/30549372/86696


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ x ] I acknowledge that all my contributions will be made under the project's license.
