### PR TITLE
Loosen hard php version restriction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3",


### PR DESCRIPTION
While we only officially support versions >=7.1 currently, we don't need to forcefully break older integrations.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
