### PR TITLE
Make docker-build work with new Dockerfile format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ you are working:
 
 ## <a name="testing"></a> Local Testing with Docker
 
-We have included a [Dockerfile](https://github.com/twilio/twilio-php/blob/master/Dockerfile) that enables easy local testing, given a specified PHP version.
+We have included a [Dockerfile](https://github.com/twilio/twilio-php/blob/master/Dockerfile-dev) that enables easy local testing, given a specified PHP version.
 
 Sample simple workflow:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
-ARG version
-FROM php:$version
+FROM php:5.6
+
+RUN mkdir /twilio
+WORKDIR /twilio
+
+COPY Twilio ./Twilio
+COPY Services ./Services
+COPY composer* ./
 
 RUN curl --silent --show-error https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
-
-RUN  apt-get update -y && \
-     apt-get upgrade -y && \
-     apt-get dist-upgrade -y && \
-     apt-get -y autoremove && \
-     apt-get clean
-
-RUN apt-get install -y zip unzip git
-
-ENV COMPOSER_ALLOW_SUPERUSER=1
-WORKDIR /twilio
+RUN composer install --no-dev

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,16 @@
+ARG version
+FROM php:$version
+
+RUN curl --silent --show-error https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+
+RUN  apt-get update -y && \
+     apt-get upgrade -y && \
+     apt-get dist-upgrade -y && \
+     apt-get -y autoremove && \
+     apt-get clean
+
+RUN apt-get install -y zip unzip git
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+WORKDIR /twilio

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ authors:
 
 API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cut -d ' ' -f 5)
 docker-build:
-	docker build -t twilio/twilio-php .
+	docker build -t twilio/twilio-php --build-arg version=5.6 .
 	docker tag twilio/twilio-php twilio/twilio-php:${TRAVIS_TAG}
 	docker tag twilio/twilio-php twilio/twilio-php:apidefs-${API_DEFINITIONS_SHA}
 	docker tag twilio/twilio-php twilio/twilio-php:latest

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ authors:
 
 API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cut -d ' ' -f 5)
 docker-build:
-	docker build -t twilio/twilio-php --build-arg version=5.6 .
+	docker build -t twilio/twilio-php .
 	docker tag twilio/twilio-php twilio/twilio-php:${TRAVIS_TAG}
 	docker tag twilio/twilio-php twilio/twilio-php:apidefs-${API_DEFINITIONS_SHA}
 	docker tag twilio/twilio-php twilio/twilio-php:latest
@@ -50,7 +50,7 @@ docker-push:
 docker-dev-build:
 	-docker stop twilio_php${VERSION}
 	-docker rm twilio_php${VERSION}
-	docker image build --tag="twilio/php${VERSION}" --build-arg version=${VERSION} -f ./Dockerfile .
+	docker image build --tag="twilio/php${VERSION}" --build-arg version=${VERSION} -f ./Dockerfile-dev .
 	docker run -itd --name="twilio_php${VERSION}" --mount type=bind,source=${PWD},target=/twilio twilio/php${VERSION} /bin/bash
 
 docker-dev-clean:


### PR DESCRIPTION
A fix per @childish-sambino's comment [here](https://github.com/twilio/twilio-php/commit/b415efdb41a6e48a95f9659001fca9f8121dcc5f#r34968353).

The docker-build command needs to pass in a version to work with the new Dockerfile format.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
