### PR TITLE
Allow for usage of older PHP unit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3",
         "apigen/apigen": "^4.1",
-        "phpunit/phpunit": ">=7.5"
+        "phpunit/phpunit": ">=4.5"
     },
     "suggest": {
         "guzzlehttp/guzzle": "An HTTP client to execute the API requests"


### PR DESCRIPTION
Follow up to #560 as version 5.6 of PHP requires a lower version of PHPUnit.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
