### PR TITLE
Support running docker tests in Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,12 @@ docker-dev-build:
 	-docker stop twilio_php${VERSION}
 	-docker rm twilio_php${VERSION}
 	docker image build --tag="twilio/php${VERSION}" --build-arg version=${VERSION} -f ./Dockerfile-dev .
-	docker run -itd --name="twilio_php${VERSION}" --mount type=bind,source=${PWD},target=/twilio twilio/php${VERSION} /bin/bash
+	docker run -td --name="twilio_php${VERSION}" --mount type=bind,source=${PWD},target=/twilio twilio/php${VERSION} /bin/bash
 
 docker-dev-clean:
 	docker ps --format '{{.Names}}' | grep "^twilio_php" | xargs -I {} sh -c "docker stop {} && docker rm {}" > /dev/null
 
 docker-dev-test:
-	docker exec -it twilio_php${VERSION} /bin/bash -c 'make all'
+	docker exec -t twilio_php${VERSION} /bin/bash -c 'make all'
 
 .PHONY: all clean test docs docs-install test-install authors docker-dev-build docker-dev-clean docker-dev-test


### PR DESCRIPTION
Tests within Jenkins jobs currently fail because Jenkins don't support interactive terminals. This PR removes the interactive terminal

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
