### PR TITLE
Dependency Fix for PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3",
         "apigen/apigen": "^4.1",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": ">=4.5"
     },
     "suggest": {
         "guzzlehttp/guzzle": "An HTTP client to execute the API requests"
@@ -30,11 +30,6 @@
     "autoload-dev": {
         "psr-4": {
             "Twilio\\Tests\\": "tests/Twilio/"
-        }
-    },
-    "config": {
-        "platform": {
-            "php": "7.1.30"
         }
     }
 }


### PR DESCRIPTION
This resolves an issue where we are failing tests on versions higher than 7.2.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
