### PR TITLE
Drop the guzzle client test return type

### DIFF
--- a/tests/Twilio/Php7UnitTest.php
+++ b/tests/Twilio/Php7UnitTest.php
@@ -6,19 +6,17 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * This file is placed outside of the Unit test suite to prevent parse errors by earlier PHP versions.
- *
- * Void keyword is available since 7.1.
  */
 abstract class UnitTest extends TestCase
 {
-    protected function setUp(): void
+    protected function setUp()
     {
         if (method_exists($this, 'doSetUp')) {
             $this->doSetUp();
         }
     }
 
-    protected function tearDown(): void
+    protected function tearDown()
     {
         if (method_exists($this, 'doTearDown')) {
             $this->doTearDown();

--- a/tests/Twilio/Unit/Http/GuzzleClientTest.php
+++ b/tests/Twilio/Unit/Http/GuzzleClientTest.php
@@ -27,7 +27,7 @@ final class GuzzleClientTest extends UnitTest
      */
     private $mockHandler;
 
-    public function setUp(): void
+    public function setUp()
     {
         parent::setUp();
         $this->mockHandler = new MockHandler();


### PR DESCRIPTION
We haven't added return type support yet.