### PR TITLE
fix: Curl client now handles proxy responses over HTTP/1.0

### DIFF
--- a/src/Twilio/Http/CurlClient.php
+++ b/src/Twilio/Http/CurlClient.php
@@ -43,7 +43,7 @@ class CurlClient implements Client {
 
             $parts = \explode("\r\n\r\n", $response, 3);
             list($head, $body) = ($parts[0] == 'HTTP/1.1 100 Continue'
-                            || $parts[0] == 'HTTP/1.1 200 Connection established')
+                            || preg_match('/\AHTTP\/1.\d 200 Connection established\Z/', $parts[0]))
                                ? array($parts[1], $parts[2])
                                : array($parts[0], $parts[1]);
 

--- a/src/Twilio/Http/CurlClient.php
+++ b/src/Twilio/Http/CurlClient.php
@@ -42,8 +42,8 @@ class CurlClient implements Client {
             }
 
             $parts = \explode("\r\n\r\n", $response, 3);
-            list($head, $body) = (preg_match('/\AHTTP\/1.\d 100 Continue\Z/', $parts[0])
-                            || preg_match('/\AHTTP\/1.\d 200 Connection established\Z/', $parts[0]))
+            list($head, $body) = (\preg_match('/\AHTTP\/1.\d 100 Continue\Z/', $parts[0])
+                               || \preg_match('/\AHTTP\/1.\d 200 Connection established\Z/', $parts[0]))
                                ? array($parts[1], $parts[2])
                                : array($parts[0], $parts[1]);
 

--- a/src/Twilio/Http/CurlClient.php
+++ b/src/Twilio/Http/CurlClient.php
@@ -42,7 +42,7 @@ class CurlClient implements Client {
             }
 
             $parts = \explode("\r\n\r\n", $response, 3);
-            list($head, $body) = ($parts[0] == 'HTTP/1.1 100 Continue'
+            list($head, $body) = (preg_match('/\AHTTP\/1.\d 100 Continue\Z/', $parts[0])
                             || preg_match('/\AHTTP\/1.\d 200 Connection established\Z/', $parts[0]))
                                ? array($parts[1], $parts[2])
                                : array($parts[0], $parts[1]);


### PR DESCRIPTION
An error occurred when I was using an HTTP / 1.0 proxy.

@see #575

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
