### PR TITLE
fix: only pass query option to Guzzle client if it is provided

### DIFF
--- a/src/Twilio/Http/GuzzleClient.php
+++ b/src/Twilio/Http/GuzzleClient.php
@@ -32,12 +32,17 @@ final class GuzzleClient implements Client
         $timeout = null
     ) {
         try {
-            $response = $this->client->send(new Request($method, $url, $headers), [
+            $options = [
                 'timeout' => $timeout,
                 'auth' => [$user, $password],
-                'query' => $params,
                 'form_params' => $data,
-            ]);
+            ];
+
+            if ($params) {
+                $options['query'] = $params;
+            }
+
+            $response = $this->client->send(new Request($method, $url, $headers), $options);
         } catch (BadResponseException $exception) {
             $response = $exception->getResponse();
         } catch (\Exception $exception) {

--- a/tests/Twilio/Unit/Http/GuzzleClientTest.php
+++ b/tests/Twilio/Unit/Http/GuzzleClientTest.php
@@ -40,7 +40,7 @@ final class GuzzleClientTest extends UnitTest
     {
         $this->mockHandler->append(new Response());
         $response = $this->client->request('post', 'https://www.whatever.com', ['myquerykey' => 'myqueryvalue'], ['myparamkey' => 'myparamvalue']);
-        $this->assertSame(null, $response->getContent());
+        $this->assertNull($response->getContent());
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame([], $response->getHeaders());
 
@@ -55,7 +55,7 @@ final class GuzzleClientTest extends UnitTest
     {
         $this->mockHandler->append(new BadResponseException('Not found', new Request('get', 'https://www.whatever.com'), new Response(404)));
         $response = $this->client->request('post', 'https://www.whatever.com', ['myquerykey' => 'myqueryvalue'], ['myparamkey' => 'myparamvalue']);
-        $this->assertSame(null, $response->getContent());
+        $this->assertNull($response->getContent());
         $this->assertSame(404, $response->getStatusCode());
         $this->assertSame([], $response->getHeaders());
 
@@ -71,5 +71,14 @@ final class GuzzleClientTest extends UnitTest
         $this->mockHandler->append(new RequestException('Not found', new Request('get', 'https://www.whatever.com')));
         $this->expectException(HttpException::class, 'Unable to complete the HTTP request');
         $this->client->request('post', 'https://www.whatever.com', ['myquerykey' => 'myqueryvalue'], ['myparamkey' => 'myparamvalue']);
+    }
+
+    public function testQueryParams()
+    {
+        $this->mockHandler->append(new Response());
+        $this->client->request('get', 'https://www.whatever.com?foo=bar');
+        $request = $this->mockHandler->getLastRequest();
+
+        $this->assertSame('https://www.whatever.com?foo=bar', (string)$request->getUri());
     }
 }

--- a/tests/Twilio/Unit/Jwt/ClientTokenTest.php
+++ b/tests/Twilio/Unit/Jwt/ClientTokenTest.php
@@ -12,33 +12,33 @@ class ClientTokenTest extends UnitTest {
     public function testNoPermissions() {
         $token = new ClientToken('AC123', 'foo');
         $payload = JWT::decode($token->generateToken(), 'foo');
-        $this->assertEquals($payload->iss, "AC123");
+        $this->assertEquals($payload->iss, 'AC123');
         $this->assertEquals($payload->scope, '');
     }
 
     public function testInboundPermissions() {
         $token = new ClientToken('AC123', 'foo');
-        $token->allowClientIncoming("andy");
+        $token->allowClientIncoming('andy');
         $payload = JWT::decode($token->generateToken(), 'foo');
 
-        $eurl = "scope:client:incoming?clientName=andy";
+        $eurl = 'scope:client:incoming?clientName=andy';
         $this->assertEquals($payload->scope, $eurl);
     }
 
     public function testOutboundPermissions() {
         $token = new ClientToken('AC123', 'foo');
-        $token->allowClientOutgoing("AP123");
-        $payload = JWT::decode($token->generateToken(), 'foo');;
-        $eurl = "scope:client:outgoing?appSid=AP123";
-        $this->assertContains($eurl, $payload->scope);
+        $token->allowClientOutgoing('AP123');
+        $payload = JWT::decode($token->generateToken(), 'foo');
+        $eurl = 'scope:client:outgoing?appSid=AP123';
+        $this->assertStringContainsString($eurl, $payload->scope);
     }
 
     public function testOutboundPermissionsParams() {
         $token = new ClientToken('AC123', 'foo');
-        $token->allowClientOutgoing("AP123", array("foobar" => 3));
+        $token->allowClientOutgoing('AP123', ['foobar' => 3]);
         $payload = JWT::decode($token->generateToken(), 'foo');
 
-        $eurl = "scope:client:outgoing?appSid=AP123&appParams=foobar%3D3";
+        $eurl = 'scope:client:outgoing?appSid=AP123&appParams=foobar%3D3';
         $this->assertEquals($payload->scope, $eurl);
     }
 
@@ -47,18 +47,18 @@ class ClientTokenTest extends UnitTest {
         $token->allowEventStream();
         $payload = JWT::decode($token->generateToken(), 'foo');
 
-        $event_uri = "scope:stream:subscribe?path=%2F2010"
-            . "-04-01%2FEvents&params=";
+        $event_uri = 'scope:stream:subscribe?path=%2F2010'
+            . '-04-01%2FEvents&params=';
         $this->assertEquals($payload->scope, $event_uri);
     }
 
     public function testEventsWithFilters() {
         $token = new ClientToken('AC123', 'foo');
-        $token->allowEventStream(array("foobar" => "hey"));
+        $token->allowEventStream(['foobar' => 'hey']);
         $payload = JWT::decode($token->generateToken(), 'foo');
 
-        $event_uri = "scope:stream:subscribe?path=%2F2010-"
-            . "04-01%2FEvents&params=foobar%3Dhey";
+        $event_uri = 'scope:stream:subscribe?path=%2F2010-'
+            . '04-01%2FEvents&params=foobar%3Dhey';
         $this->assertEquals($payload->scope, $event_uri);
     }
 
@@ -74,21 +74,21 @@ class ClientTokenTest extends UnitTest {
 
     public function testDecode() {
         $token = new ClientToken('AC123', 'foo');
-        $token->allowClientOutgoing("AP123", array("foobar"=> 3));
-        $token->allowClientIncoming("andy");
+        $token->allowClientOutgoing('AP123', ['foobar' => 3]);
+        $token->allowClientIncoming('andy');
         $token->allowEventStream();
 
-        $outgoing_uri = "scope:client:outgoing?appSid="
-            . "AP123&appParams=foobar%3D3&clientName=andy";
-        $incoming_uri = "scope:client:incoming?clientName=andy";
-        $event_uri = "scope:stream:subscribe?path=%2F2010-04-01%2FEvents";
+        $outgoing_uri = 'scope:client:outgoing?appSid='
+            . 'AP123&appParams=foobar%3D3&clientName=andy';
+        $incoming_uri = 'scope:client:incoming?clientName=andy';
+        $event_uri = 'scope:stream:subscribe?path=%2F2010-04-01%2FEvents';
 
         $payload = JWT::decode($token->generateToken(), 'foo');
         $scope = $payload->scope;
 
-        $this->assertContains($outgoing_uri, $scope);
-        $this->assertContains($incoming_uri, $scope);
-        $this->assertContains($event_uri, $scope);
+        $this->assertStringContainsString($outgoing_uri, $scope);
+        $this->assertStringContainsString($incoming_uri, $scope);
+        $this->assertStringContainsString($event_uri, $scope);
     }
 
 
@@ -112,7 +112,7 @@ class ClientTokenTest extends UnitTest {
     function zeroLengthNameInvalid() {
         $this->expectException('InvalidArgumentException');
         $token = new ClientToken('AC123', 'foo');
-        $token->allowClientIncoming("");
+        $token->allowClientIncoming('');
         $this->fail('exception should have been raised');
     }
 }

--- a/tests/Twilio/Unit/Rest/ClientTest.php
+++ b/tests/Twilio/Unit/Rest/ClientTest.php
@@ -3,6 +3,8 @@
 
 namespace Twilio\Tests\Unit\Rest;
 
+use Twilio\Exceptions\ConfigurationException;
+use Twilio\Exceptions\TwilioException;
 use Twilio\Http\CurlClient;
 use Twilio\Http\Response;
 use Twilio\Rest\Client;
@@ -12,25 +14,19 @@ use Twilio\Tests\Unit\UnitTest;
 
 class ClientTest extends UnitTest {
 
-    /**
-     * @expectedException \Twilio\Exceptions\ConfigurationException
-     */
-    public function testThrowsWhenUsernameAndPasswordMissing() {
-        new Client(null, null, null, null, null, array());
+    public function testThrowsWhenUsernameAndPasswordMissing(): void {
+        $this->expectException(ConfigurationException::class);
+        new Client(null, null, null, null, null, []);
     }
 
-    /**
-     * @expectedException \Twilio\Exceptions\ConfigurationException
-     */
-    public function testThrowsWhenUsernameMissing() {
-        new Client(null, 'password', null, null, null, array());
+    public function testThrowsWhenUsernameMissing(): void {
+        $this->expectException(ConfigurationException::class);
+        new Client(null, 'password', null, null, null, []);
     }
 
-    /**
-     * @expectedException \Twilio\Exceptions\ConfigurationException
-     */
-    public function testThrowsWhenPasswordMissing() {
-        new Client('username', null, null, null, null, array());
+    public function testThrowsWhenPasswordMissing(): void {
+        $this->expectException(ConfigurationException::class);
+        new Client('username', null, null, null, null, []);
     }
 
     public function testUsernamePulledFromEnvironment() {
@@ -123,10 +119,8 @@ class ClientTest extends UnitTest {
 		$client->validateSslCertificate($curlClient);
 	}
 
-	/**
-	 * @expectedException \Twilio\Exceptions\TwilioException
-	 */
 	public function testValidationSslCertificateError() {
+        $this->expectException(TwilioException::class);
 		$client = new Client('username', 'password');
 		$curlClient = $this->createMock(CurlClient::class);
 		$curlClient
@@ -134,7 +128,7 @@ class ClientTest extends UnitTest {
             ->method('request')
 			->willReturn(new Response(504, ''))
         ;
-		
+
 		$client->validateSslCertificate($curlClient);
 	}
 


### PR DESCRIPTION
Fixes #592 