### PR TITLE
fix: allow for older versions of PHP to install via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3",


### PR DESCRIPTION
### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license