### PR TITLE
fix: support array parameters for Guzzle POSTs

### DIFF
--- a/src/Twilio/Http/GuzzleClient.php
+++ b/src/Twilio/Http/GuzzleClient.php
@@ -8,6 +8,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Psr7\Request;
 use Twilio\Exceptions\HttpException;
+use function GuzzleHttp\Psr7\build_query;
 
 final class GuzzleClient implements Client {
     /**
@@ -24,10 +25,12 @@ final class GuzzleClient implements Client {
                             string $user = null, string $password = null,
                             int $timeout = null): Response {
         try {
+            $body = build_query($data, PHP_QUERY_RFC1738);
+
             $options = [
                 'timeout' => $timeout,
                 'auth' => [$user, $password],
-                'form_params' => $data,
+                'body' => $body,
             ];
 
             if ($params) {
@@ -40,6 +43,7 @@ final class GuzzleClient implements Client {
         } catch (\Exception $exception) {
             throw new HttpException('Unable to complete the HTTP request', 0, $exception);
         }
+
         // Casting the body (stream) to a string performs a rewind, ensuring we return the entire response.
         // See https://stackoverflow.com/a/30549372/86696
         return new Response($response->getStatusCode(), (string)$response->getBody(), $response->getHeaders());

--- a/tests/Twilio/Unit/Http/GuzzleClientTest.php
+++ b/tests/Twilio/Unit/Http/GuzzleClientTest.php
@@ -48,6 +48,20 @@ final class GuzzleClientTest extends UnitTest {
         $this->assertSame('https://www.whatever.com?myquerykey=myqueryvalue', (string)$request->getUri());
     }
 
+    public function testPostMethodArray(): void {
+        $this->mockHandler->append(new Response());
+        $response = $this->client->request('post', 'https://www.whatever.com', [], ['key' => ['value1', 'value2']]);
+        $this->assertNull($response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([], $response->getHeaders());
+
+        $request = $this->mockHandler->getLastRequest();
+
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('key=value1&key=value2', $request->getBody()->getContents());
+        $this->assertSame('https://www.whatever.com', (string)$request->getUri());
+    }
+
     public function testPostMethodThatThrowsBadResponseException(): void {
         $this->mockHandler->append(new BadResponseException('Not found', new Request('get', 'https://www.whatever.com'), new Response(404)));
         $response = $this->client->request('post', 'https://www.whatever.com', ['myquerykey' => 'myqueryvalue'], ['myparamkey' => 'myparamvalue']);
@@ -68,8 +82,7 @@ final class GuzzleClientTest extends UnitTest {
         $this->client->request('post', 'https://www.whatever.com', ['myquerykey' => 'myqueryvalue'], ['myparamkey' => 'myparamvalue']);
     }
 
-    public function testQueryParams()
-    {
+    public function testQueryParams(): void {
         $this->mockHandler->append(new Response());
         $this->client->request('get', 'https://www.whatever.com?foo=bar');
         $request = $this->mockHandler->getLastRequest();


### PR DESCRIPTION
Guzzle defaults to using array-based POST parameters (e.g., `foo[]=1&foo[]=2`) instead of sending multiple values for the same key (e.g., `foo=1&foo=2`) which is what the Twilio API supports. This change builds body using the proper `application/x-www-form-urlencoded` type.

Fixes #649 