### PR TITLE
feat: Add region to access token

### DIFF
--- a/src/Twilio/Jwt/AccessToken.php
+++ b/src/Twilio/Jwt/AccessToken.php
@@ -12,16 +12,18 @@ class AccessToken {
     private $ttl;
     private $identity;
     private $nbf;
+    private $region;
     /** @var Grant[] $grants */
     private $grants;
     /** @var string[] $customClaims */
     private $customClaims;
 
-    public function __construct(string $accountSid, string $signingKeySid, string $secret, int $ttl = 3600, string $identity = null) {
+    public function __construct(string $accountSid, string $signingKeySid, string $secret, int $ttl = 3600, string $identity = null, string $region = null) {
         $this->signingKeySid = $signingKeySid;
         $this->accountSid = $accountSid;
         $this->secret = $secret;
         $this->ttl = $ttl;
+        $this->region = $region;
 
         if ($identity !== null) {
             $this->identity = $identity;
@@ -74,6 +76,27 @@ class AccessToken {
     }
 
     /**
+     * Set the region of this access token
+     *
+     * @param string $region Home region of the account sid in this access token
+     *
+     * @return $this updated access token
+     */
+    public function setRegion(string $region): self {
+        $this->region = $region;
+        return $this;
+    }
+
+    /**
+     * Returns the region of this access token
+     *
+     * @return string Home region of the account sid in this access token
+     */
+    public function getRegion(): string {
+        return $this->region;
+    }
+
+    /**
      * Add a grant to the access token
      *
      * @param Grant $grant to be added
@@ -100,6 +123,10 @@ class AccessToken {
             'cty' => 'twilio-fpa;v=1',
             'typ' => 'JWT'
         ];
+
+        if ($this->region) {
+            $header['twr'] = $this->region;
+        }
 
         $now = \time();
 

--- a/src/Twilio/Jwt/JWT.php
+++ b/src/Twilio/Jwt/JWT.php
@@ -46,6 +46,24 @@ class JWT {
     }
 
     /**
+     * @param string $jwt The JWT
+     * @return object The JWT's header as a PHP object
+     * @throws \UnexpectedValueException
+     */
+    public static function getHeader(string $jwt) {
+        $tks = \explode('.', $jwt);
+        if (\count($tks) !== 3) {
+            throw new \UnexpectedValueException('Wrong number of segments');
+        }
+        list($headb64) = $tks;
+        if (null === ($header = self::jsonDecode(self::urlsafeB64Decode($headb64)))
+        ) {
+            throw new \UnexpectedValueException('Invalid segment encoding');
+        }
+        return $header;
+    }
+
+    /**
      * @param object|array $payload PHP object or array
      * @param string $key The secret key
      * @param string $algo The signing algorithm

--- a/tests/Twilio/Unit/Jwt/AccessTokenTest.php
+++ b/tests/Twilio/Unit/Jwt/AccessTokenTest.php
@@ -40,6 +40,29 @@ class AccessTokenTest extends UnitTest {
         $this->assertEquals('{}', \json_encode($payload->grants));
     }
 
+    public function testMissingRegion(): void {
+        $scat = new AccessToken(self::ACCOUNT_SID, self::SIGNING_KEY_SID, 'secret');
+        $token = $scat->toJWT();
+        $this->assertNotNull($token);
+        $header = JWT::getHeader($token);
+
+        $this->assertEquals('twilio-fpa;v=1', $header->cty);
+        $this->assertEquals('JWT', $header->typ);
+        $this->assertEquals(false, property_exists($header, 'twr'));
+    }
+
+    public function testValidRegion(): void {
+        $scat = new AccessToken(self::ACCOUNT_SID, self::SIGNING_KEY_SID, 'secret');
+        $scat->setRegion('foo');
+        $token = $scat->toJWT();
+        $this->assertNotNull($token);
+        $header = JWT::getHeader($token);
+
+        $this->assertEquals('twilio-fpa;v=1', $header->cty);
+        $this->assertEquals('JWT', $header->typ);
+        $this->assertEquals('foo', $header->twr);
+    }
+
     public function testNbf(): void {
         $scat = new AccessToken(self::ACCOUNT_SID, self::SIGNING_KEY_SID, 'secret');
 


### PR DESCRIPTION
# Feature #

This PR adds AccessTokenOptions.region parameter to support regional authentication. This value will be encoded in the twr header of the JWT. If the parameter is not specified or invalid, no twr value is added. See this document for more details.
JIRA: https://issues.corp.twilio.com/browse/CLIENT-8142

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified