### PR TITLE
chore: ignore directory and not just the content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-vendor/*
+vendor/
 composer.phar
 composer.lock
 coverage


### PR DESCRIPTION
This makes sure `git clean -df` doesn't remove the `vendor` directory in librarian