### PR TITLE
fix: use offset +0000 for iso8601 conversions

### DIFF
--- a/src/Twilio/Serialize.php
+++ b/src/Twilio/Serialize.php
@@ -40,7 +40,7 @@ class Serialize {
         }
 
         $utcDate = clone $dateTime;
-        $utcDate->setTimezone(new \DateTimeZone('UTC'));
+        $utcDate->setTimezone(new \DateTimeZone('+0000'));
         return $utcDate->format('Y-m-d');
     }
 
@@ -54,7 +54,7 @@ class Serialize {
         }
 
         $utcDate = clone $dateTime;
-        $utcDate->setTimezone(new \DateTimeZone('UTC'));
+        $utcDate->setTimezone(new \DateTimeZone('+0000'));
         return $utcDate->format('Y-m-d\TH:i:s\Z');
     }
 

--- a/tests/Twilio/Unit/SerializeTest.php
+++ b/tests/Twilio/Unit/SerializeTest.php
@@ -91,7 +91,7 @@ class SerializeTest extends UnitTest {
     }
 
     public function testIso8601DateTimeSameTimezone(): void {
-        $date = new \DateTime('2017-02-01T17:15:41', new \DateTimeZone('UTC'));
+        $date = new \DateTime('2017-02-01T17:15:41', new \DateTimeZone('+0000'));
         $actual = Serialize::iso8601DateTime($date);
         $this->assertEquals('2017-02-01T17:15:41Z', $actual);
     }


### PR DESCRIPTION
Seeing issue on build system where UTC is showing as offset -0800. which is absurd.