### PR TITLE
fix: use offset +0000 for iso8601 conversion

### DIFF
--- a/tests/Twilio/Unit/SerializeTest.php
+++ b/tests/Twilio/Unit/SerializeTest.php
@@ -60,7 +60,7 @@ class SerializeTest extends UnitTest {
     }
 
     public function testIso8601DateSameTimezone(): void {
-        $date = new \DateTime('now', new \DateTimeZone('UTC'));
+        $date = new \DateTime('now', new \DateTimeZone('+0000'));
         $actual = Serialize::iso8601Date($date);
         $this->assertEquals($date->format('Y-m-d'), $actual);
     }


### PR DESCRIPTION
Found while testing the deploy in dev.