### PR TITLE
fix: `capabilities` property type doc

### DIFF
--- a/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumberInstance.php
+++ b/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumberInstance.php
@@ -23,7 +23,7 @@ use Twilio\Version;
  * @property string $addressRequirements
  * @property string $apiVersion
  * @property bool $beta
- * @property string $capabilities
+ * @property array $capabilities
  * @property \DateTime $dateCreated
  * @property \DateTime $dateUpdated
  * @property string $friendlyName


### PR DESCRIPTION
The `capabilities` property is an array of string keys with bool values, instead of a `string` property as declared on the `IncomingPhoneNumberList` resource.

https://www.twilio.com/docs/phone-numbers/api/incomingphonenumber-resource#create-an-incomingphonenumber-resource

```php
$phoneNumber = $twilio->incomingPhoneNumbers->read()[0];

// array:4 [
//   "fax" => false
//   "voice" => true
//   "sms" => true
//   "mms" => true
// ]
var_dump($phoneNumber->capabilities);
```