### PR TITLE
fix: Disable redirects for the Guzzle HTTP client

### DIFF
--- a/src/Twilio/Http/GuzzleClient.php
+++ b/src/Twilio/Http/GuzzleClient.php
@@ -31,6 +31,7 @@ final class GuzzleClient implements Client {
                 'timeout' => $timeout,
                 'auth' => [$user, $password],
                 'body' => $body,
+                'allow_redirects' => false,
             ];
 
             if ($params) {

--- a/tests/Twilio/Unit/Http/GuzzleClientTest.php
+++ b/tests/Twilio/Unit/Http/GuzzleClientTest.php
@@ -46,6 +46,10 @@ final class GuzzleClientTest extends UnitTest {
         $this->assertSame('POST', $request->getMethod());
         $this->assertSame('myparamkey=myparamvalue', $request->getBody()->getContents());
         $this->assertSame('https://www.whatever.com?myquerykey=myqueryvalue', (string)$request->getUri());
+
+        $options = $this->mockHandler->getLastOptions();
+
+        $this->assertFalse($options['allow_redirects']);
     }
 
     public function testPostMethodArray(): void {


### PR DESCRIPTION
There is a discrepancy in the Guzzle-based HTTP client implementation with the default behavior for the CURL client. After studying the implementation and the behavior of the CURL client, I concluded that redirects following are not enabled for it. The Guzzle client, on the other hand, follows redirects by default. Nowhere in the documentation is it mentioned that the client must be configured in a particular way, and therefore the necessary behavior must be provided by the Twilio library.

This fix disables redirect following for the Guzzle client so that the behavior corresponds to the one in the CURL implementation.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified