### PR TITLE
fix: support array parameters for Guzzle GETs

### DIFF
--- a/src/Twilio/Http/GuzzleClient.php
+++ b/src/Twilio/Http/GuzzleClient.php
@@ -32,7 +32,7 @@ final class GuzzleClient implements Client {
             ];
 
             if ($params) {
-                $options['query'] = $params;
+                $options['query'] = Query::build($params, PHP_QUERY_RFC1738);
             }
 
             if ($method === 'POST') {

--- a/tests/Twilio/Unit/Http/GuzzleClientTest.php
+++ b/tests/Twilio/Unit/Http/GuzzleClientTest.php
@@ -116,4 +116,17 @@ final class GuzzleClientTest extends UnitTest {
 
         $this->assertSame('https://www.whatever.com?foo=bar', (string)$request->getUri());
     }
+
+    public function testGetMethodArray(): void {
+        $this->mockHandler->append(new Response());
+        $response = $this->client->request('GET', 'https://www.whatever.com', ['key' => ['value1']]);
+        $this->assertNull($response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([], $response->getHeaders());
+
+        $request = $this->mockHandler->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('https://www.whatever.com?key=value1', (string)$request->getUri());
+    }
 }


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes [DII-794](https://issues.corp.twilio.com/browse/DII-794)

Updated Guzzle Client to support sending query params with multiple values for the same key (e.g. `foo=1&foo=2`) which is what the Twilio API supports. 

Fixes #752 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
