### PR TITLE
Correct version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0"
+        "php": "^7.2.5 || ^8.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "phpunit/phpunit": ">=7.0 < 10"
+        "guzzlehttp/guzzle": "^7.5.1",
+        "phpunit/phpunit": "^8.5.33 || ^9.6.7"
     },
     "suggest": {
         "guzzlehttp/guzzle": "An HTTP client to execute the API requests"

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.5.1",
+        "guzzlehttp/psr7": "^2.4.5",
         "phpunit/phpunit": "^8.5.33 || ^9.6.7"
     },
     "suggest": {


### PR DESCRIPTION
# Fixes #

The PHP version constraint was incorrect, and the other dev-deps were unnecessarily low, which will cause issues for PHP 8.2 compatibility (coming in a follow-up PR). FYI, Guzzle 6 is approaching EOL, and I would not recommend using anything other than the latest version of Guzzle 7, since earlier versions have security vulnerabilities, or don't deny installation of transitive dependencies which have security vulnerabilities (I am co-maintainer of Guzzle).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
