### PR TITLE
fix: Issue with statusCallbackEvent argument type

### DIFF
--- a/src/Twilio/TwiML/Voice/Number.php
+++ b/src/Twilio/TwiML/Voice/Number.php
@@ -52,9 +52,10 @@ class Number extends TwiML {
     /**
      * Add StatusCallbackEvent attribute.
      *
-     * @param string[] $statusCallbackEvent Events to call status callback
+     * @param string[]|string $statusCallbackEvent Events to call status callback
      */
     public function setStatusCallbackEvent($statusCallbackEvent): self {
+        $statusCallbackEvent = is_array($statusCallbackEvent) ? implode(' ', $statusCallbackEvent) : $statusCallbackEvent;
         return $this->setAttribute('statusCallbackEvent', $statusCallbackEvent);
     }
 


### PR DESCRIPTION
# Fixes #

Solved an issue where the suggested type for the statusCallbackEvent method is not accepted by the underlying setAttribute method.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified