### PR TITLE
chore: remove urls that do not belong to Twilio anymore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4182,9 +4182,9 @@ Version 3.8.1
 
 Released on November 23, 2012
 
-- [Implements the Countable interface on the ListResource][countable], so you
+- Implements the Countable interface on the ListResource, so you
   can call count() on any resource.
-- [Adds a convenience method for retrieving a phone number object][get-number],
+- Adds a convenience method for retrieving a phone number object,
   so you can retrieve all of a number's properties by its E.164 representation.
 
 Internally:
@@ -4193,8 +4193,6 @@ Internally:
 - Updates [Travis CI configuration to use Composer][travis-composer],
 shortening build time from 83 seconds to 21 seconds.
 
-[countable]: https://twilio-php.readthedocs.org/en/latest/usage/rest.html#retrieving-the-total-number-of-resources
-[get-number]: https://twilio-php.readthedocs.org/en/latest/usage/rest/phonenumbers.html#retrieving-all-of-a-number-s-properties
 [unicode-tests]: https://github.com/twilio/twilio-php/commit/6f8aa57885796691858e460c8cea748e241c47e3
 [travis-composer]: https://github.com/twilio/twilio-php/commit/a732358e90e1ae9a5a3348ad77dda8cc8b5ec6bc
 
@@ -4204,10 +4202,7 @@ Version 3.8.0
 Released on October 17, 2012
 
 - Support the new Usage API, with Usage Records and Usage Triggers. Read the
-  PHP documentation for [usage records][records] or [usage triggers][triggers]
-
-  [records]: https://twilio-php.readthedocs.org/en/latest/usage/rest/usage-records.html
-  [triggers]: https://twilio-php.readthedocs.org/en/latest/usage/rest/usage-triggers.html
+  PHP documentation for usage records or usage triggers
 
 Version 3.7.2
 -------------


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

https://twilio-php.readthedocs.io/en/latest/ does not belong to Twilio anymore, so removing those links for security reasons.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
