### PR TITLE
Misc: Remove AWS Example Key From PHPDoc

### DIFF
--- a/src/Twilio/Rest/Accounts/V1/Credential/AwsList.php
+++ b/src/Twilio/Rest/Accounts/V1/Credential/AwsList.php
@@ -46,7 +46,7 @@ class AwsList extends ListResource
     /**
      * Create the AwsInstance
      *
-     * @param string $credentials A string that contains the AWS access credentials in the format `<AWS_ACCESS_KEY_ID>:<AWS_SECRET_ACCESS_KEY>`. For example, `AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`
+     * @param string $credentials A string that contains the AWS access credentials in the format `<AWS_ACCESS_KEY_ID>:<AWS_SECRET_ACCESS_KEY>`.
      * @param array|Options $options Optional Arguments
      * @return AwsInstance Created AwsInstance
      * @throws TwilioException When an HTTP error occurs.


### PR DESCRIPTION
# Fixes #

This remediates the false-positive secret detection triggering for this package.

This is done by removing the Example key from the PHPDoc for "Create the AwsInstance"
```
     * @param string $credentials A string that contains the AWS access credentials in the format `<AWS_ACCESS_KEY_ID>:<AWS_SECRET_ACCESS_KEY>`. For example, `AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`
```
The reason for this, is that it's presence triggers alerts by default in environments that look for the presence of secrets in code, for example, Azure automatically triggers an alert:
_"Defender for Cloud found a plaintext AWS access key stored in this resource. It is important to store access keys securely to avoid leakage or misuse."_

Removing the example does not break anything, although it does admittedly increase the barriers to entry, and it then silences the alert from being triggered.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the main branch
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary documentation about the functionality in the appropriate .md file
- [X] I have added inline documentation to the code I modified