### PR TITLE
fix: updating client to only use http and https

### DIFF
--- a/src/Twilio/Http/CurlClient.php
+++ b/src/Twilio/Http/CurlClient.php
@@ -96,6 +96,7 @@ class CurlClient implements Client {
             CURLOPT_INFILESIZE => Null,
             CURLOPT_HTTPHEADER => [],
             CURLOPT_TIMEOUT => $timeout,
+            CURLOPT_PROTOCOLS => CURLPROTO_HTTPS | CURLPROTO_HTTP
         ];
 
         foreach ($headers as $key => $value) {

--- a/tests/Twilio/Unit/Http/CurlClientTest.php
+++ b/tests/Twilio/Unit/Http/CurlClientTest.php
@@ -360,7 +360,7 @@ class CurlClientTest extends UnitTest {
 
     public function testFileProtocolThrowsException(): void {
         $this->expectException(EnvironmentException::class);
-        $this->expectExceptionMessage('Unsupported protocol: file');
+        $this->expectExceptionMessage('Protocol "file" disabled');
 
         $client = new CurlClient();
         $client->request('GET', 'file:///tmp/test-file');

--- a/tests/Twilio/Unit/Http/CurlClientTest.php
+++ b/tests/Twilio/Unit/Http/CurlClientTest.php
@@ -360,7 +360,7 @@ class CurlClientTest extends UnitTest {
 
     public function testFileProtocolThrowsException(): void {
         $this->expectException(EnvironmentException::class);
-        $this->expectExceptionMessage('Protocol "file" disabled');
+        $this->expectExceptionMessage('Protocol "file" not supported or disabled in libcurl');
 
         $client = new CurlClient();
         $client->request('GET', 'file:///tmp/test-file');

--- a/tests/Twilio/Unit/Http/CurlClientTest.php
+++ b/tests/Twilio/Unit/Http/CurlClientTest.php
@@ -5,6 +5,7 @@ namespace Twilio\Tests\Unit\Http;
 
 
 use Twilio\AuthStrategy\NoAuthStrategy;
+use Twilio\Exceptions\EnvironmentException;
 use Twilio\Http\CurlClient;
 use Twilio\Http\File;
 use Twilio\Values;
@@ -355,5 +356,13 @@ class CurlClientTest extends UnitTest {
                 ],
             ],
         ];
+    }
+
+    public function testFileProtocolThrowsException(): void {
+        $this->expectException(EnvironmentException::class);
+        $this->expectExceptionMessage('Unsupported protocol: file');
+
+        $client = new CurlClient();
+        $client->request('GET', 'file:///tmp/test-file');
     }
 }


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

This PR addresses vulnerability that had no restriction for protocols that can be used by CurlClient.
This restricts it to `http` and `https`

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
