### PR TITLE
chore: disable testFetchMessageUsingPublicOAuth

### DIFF
--- a/tests/Twilio/ClusterTest.php
+++ b/tests/Twilio/ClusterTest.php
@@ -115,20 +115,20 @@ class ClusterTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($token->accessToken);
     }
 
-    public function testFetchMessageUsingPublicOAuth(): void
-    {
-       $clientCredentialProvider = (new ClientCredentialProviderBuilder())->setClientId(self::$clientId)->setClientSecret(self::$clientSecret)->build();
-       $client = new Client();
-       $client->setCredentialProvider($clientCredentialProvider);
-       $client->setAccountSid(self::$accountSid);
+    // public function testFetchMessageUsingPublicOAuth(): void
+    // {
+    //    $clientCredentialProvider = (new ClientCredentialProviderBuilder())->setClientId(self::$clientId)->setClientSecret(self::$clientSecret)->build();
+    //    $client = new Client();
+    //    $client->setCredentialProvider($clientCredentialProvider);
+    //    $client->setAccountSid(self::$accountSid);
 
-       $message = $client->messages(self::$messageSid)->fetch();
-       self::assertNotNull($message);
-       self::assertEquals(self::$messageSid, $message->sid);
-       self::assertEquals(self::$fromNumber, $message->from);
-       self::assertEquals(self::$toNumber, $message->to);
-       self::assertEquals("Where's Wallace?", $message->body);
-    }
+    //    $message = $client->messages(self::$messageSid)->fetch();
+    //    self::assertNotNull($message);
+    //    self::assertEquals(self::$messageSid, $message->sid);
+    //    self::assertEquals(self::$fromNumber, $message->from);
+    //    self::assertEquals(self::$toNumber, $message->to);
+    //    self::assertEquals("Where's Wallace?", $message->body);
+    // }
 
 
     public function testOrgsApiUserListAndFetchAndOrgsApiAccountsList(): void


### PR DESCRIPTION
Comment out the testFetchMessageUsingPublicOAuth method in ClusterTest.php.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

A short description of what this PR does.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
