### PR TITLE
fix: fix type mismatch

### DIFF
--- a/src/Twilio/Rest/Lookups/V2/PhoneNumberInstance.php
+++ b/src/Twilio/Rest/Lookups/V2/PhoneNumberInstance.php
@@ -34,7 +34,7 @@ use Twilio\Version;
  * @property string $callerName
  * @property string $simSwap
  * @property string $callForwarding
- * @property string $lineTypeIntelligence
+ * @property array|null $lineTypeIntelligence
  * @property string $lineStatus
  * @property string $identityMatch
  * @property string $reassignedNumber
@@ -146,4 +146,3 @@ class PhoneNumberInstance extends InstanceResource
         return '[Twilio.Lookups.V2.PhoneNumberInstance ' . \implode(' ', $context) . ']';
     }
 }
-


### PR DESCRIPTION
Fixes #897 

Fixes the doc type mismatch in PhoneNumberInstance.php.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
