### PR TITLE
fix: Php api std

### DIFF
--- a/src/Twilio/ApiV1Version.php
+++ b/src/Twilio/ApiV1Version.php
@@ -39,6 +39,13 @@ class ApiV1Version extends Version {
         if (\is_array($content)) {
             $message .= isset($content['message']) ? ': ' . $content['message'] : '';
             $code = $content['code'] ?? $response->getStatusCode();
+
+            if (isset($content['more_info']) || isset($content['status'])) {
+                $moreInfo = $content['more_info'] ?? '';
+                $details = $content['details'] ?? [];
+                return new RestException($message, $code, $response->getStatusCode(), $moreInfo, $details);
+            }
+
             $httpStatusCode = $content['httpStatusCode'] ?? $response->getStatusCode();
             $params = $content['params'] ?? [];
             $userError = $content['userError'] ?? false;

--- a/src/Twilio/TokenPaginationPage.php
+++ b/src/Twilio/TokenPaginationPage.php
@@ -72,8 +72,20 @@ abstract class TokenPaginationPage extends Page {
             $this->key = $this->getMeta('key');
         }
         $this->pageSize = (int) $this->getMeta('pageSize');
-        $this->nextToken = $this->getMeta('nextToken');
-        $this->previousToken = $this->getMeta('previousToken');
+        $this->nextToken = $this->hasMeta('nextToken') ? $this->getMeta('nextToken') : null;
+        $this->previousToken = $this->hasMeta('previousToken') ? $this->getMeta('previousToken') : null;
+
+        // If the nextToken matches the pageToken we just used, treat it as no more pages
+        // This prevents infinite loops when servers return the same token repeatedly
+        if ($this->nextToken && isset($this->queryParams['pageToken']) &&
+            $this->nextToken === $this->queryParams['pageToken']) {
+            $this->nextToken = null;
+        }
+
+        if ($this->previousToken && isset($this->queryParams['pageToken']) &&
+            $this->previousToken === $this->queryParams['pageToken']) {
+            $this->previousToken = null;
+        }
     }
 
     /**

--- a/src/Twilio/TokenPaginationPage.php
+++ b/src/Twilio/TokenPaginationPage.php
@@ -86,6 +86,12 @@ abstract class TokenPaginationPage extends Page {
             return $this->payload[$this->key];
         }
 
+        $keys = \array_diff(\array_keys($this->payload), ['meta']);
+        if (\count($keys) === 1) {
+            $this->key = \array_values($keys)[0];
+            return $this->payload[$this->key];
+        }
+
         throw new KeyErrorException('key not found in the response');
     }
 
@@ -135,6 +141,15 @@ abstract class TokenPaginationPage extends Page {
             $this->nextPageUrl = $this->url . $this->getQueryString($this->nextToken);
         }
         return $this->nextPageUrl;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function current() {
+        $record = $this->records->current();
+        if (!\is_array($record)) {
+            $record = ['id' => $record];
+        }
+        return $this->buildInstance($record);
     }
 
     public function __toString(): string {

--- a/src/Twilio/TokenPaginationPage.php
+++ b/src/Twilio/TokenPaginationPage.php
@@ -68,9 +68,8 @@ abstract class TokenPaginationPage extends Page {
             }
         }
 
-        $this->key = $this->getMeta('key');
         if (!$this->key) {
-            throw new KeyErrorException('key not found in the response metadata');
+            $this->key = $this->getMeta('key');
         }
         $this->pageSize = (int) $this->getMeta('pageSize');
         $this->nextToken = $this->getMeta('nextToken');

--- a/src/Twilio/TokenPaginationPage.php
+++ b/src/Twilio/TokenPaginationPage.php
@@ -69,6 +69,9 @@ abstract class TokenPaginationPage extends Page {
         }
 
         $this->key = $this->getMeta('key');
+        if (!$this->key) {
+            throw new KeyErrorException('key not found in the response metadata');
+        }
         $this->pageSize = (int) $this->getMeta('pageSize');
         $this->nextToken = $this->getMeta('nextToken');
         $this->previousToken = $this->getMeta('previousToken');

--- a/tests/Twilio/Unit/TokenPaginationPageTest.php
+++ b/tests/Twilio/Unit/TokenPaginationPageTest.php
@@ -130,16 +130,17 @@ class TokenPaginationPageTest extends TestCase
     }
 
     /**
-     * Test constructor with no metadata
+     * Test constructor with no metadata infers key from single non-meta field
      */
     public function testConstructorWithNoMetadata(): void
     {
-        // Create a response without metadata
         $response = new Response(200, '{"items": [{"id": 1}]}');
 
-        // This should throw since key is required
-        $this->expectException(KeyErrorException::class);
         $page = new TestableTokenPaginationPage($this->version, $response);
+
+        $this->assertEquals('items', $page->getKey());
+        $this->assertNull($page->getNextToken());
+        $this->assertNull($page->getPreviousToken());
     }
 
     /**


### PR DESCRIPTION
This PR fixes pagination-related bugs for APIs following Twilio API Standard V1:  
1. Infinite Loop Prevention: Prevents infinite loops when servers return the same nextToken/previousToken as the current pageToken. This edge case causes pagination to loop endlessly on the same page.          
  2. Missing Metadata Handling: Makes pagination work for list APIs that don't include meta object in responses. Now automatically infers the data key from the single non-meta field in the response.              
  3. Enhanced Error Details: Improves RestException to include more_info URL and details from RFC 9457 Problem Details error responses.                                                                             
  4. Array Record Handling: Fixes current() method to handle non-array record responses by wrapping them in an array structure.  