### PR TITLE
Preserve Guzzle client default timeout

### DIFF
--- a/src/Twilio/Http/GuzzleClient.php
+++ b/src/Twilio/Http/GuzzleClient.php
@@ -27,9 +27,12 @@ final class GuzzleClient implements Client {
                             ?int $timeout = null, ?AuthStrategy $authStrategy = null): Response {
         try {
             $options = [
-                'timeout' => $timeout,
                 'allow_redirects' => false,
             ];
+
+            if ($timeout !== null) {
+                $options['timeout'] = $timeout;
+            }
 
             if($user && $password) {
                 $headers['Authorization'] = 'Basic ' . base64_encode($user . ':' . $password);

--- a/tests/Twilio/Unit/Http/GuzzleClientTest.php
+++ b/tests/Twilio/Unit/Http/GuzzleClientTest.php
@@ -86,6 +86,36 @@ final class GuzzleClientTest extends UnitTest {
         $this->assertSame([], $response->getHeaders());
     }
 
+    public function testConfiguredGuzzleTimeoutIsUsedWhenRequestTimeoutIsNull(): void {
+        $this->mockHandler->append(new Response());
+        $client = new GuzzleClient(new Client([
+            'handler' => HandlerStack::create($this->mockHandler),
+            'timeout' => 30,
+        ]));
+
+        $client->request('GET', 'https://www.whatever.com');
+
+        $options = $this->mockHandler->getLastOptions();
+
+        $this->assertSame(30, $options['timeout']);
+        $this->assertFalse($options['allow_redirects']);
+    }
+
+    public function testRequestTimeoutOverridesConfiguredGuzzleTimeout(): void {
+        $this->mockHandler->append(new Response());
+        $client = new GuzzleClient(new Client([
+            'handler' => HandlerStack::create($this->mockHandler),
+            'timeout' => 30,
+        ]));
+
+        $client->request('GET', 'https://www.whatever.com', [], [], [], null, null, 5);
+
+        $options = $this->mockHandler->getLastOptions();
+
+        $this->assertSame(5, $options['timeout']);
+        $this->assertFalse($options['allow_redirects']);
+    }
+
     public function testPostMethodArray(): void {
         $this->mockHandler->append(new Response());
         $response = $this->client->request('POST', 'https://www.whatever.com', [], ['key' => ['value1', 'value2']]);


### PR DESCRIPTION
GuzzleClient currently passes timeout as null when Twilio does not receive a per-request timeout. That prevents timeout defaults configured on the injected Guzzle client from applying.

This only sends the timeout option when Twilio receives an explicit timeout value, matching CurlClient's behavior where null means no per-request override rather than clearing the client's configured timeout.