### PR TITLE
Use uppercase HTTP methods in tests

### DIFF
--- a/tests/Twilio/Unit/Http/GuzzleClientTest.php
+++ b/tests/Twilio/Unit/Http/GuzzleClientTest.php
@@ -121,7 +121,7 @@ final class GuzzleClientTest extends UnitTest {
     }
 
     public function testPostMethodThatThrowsBadResponseException(): void {
-        $this->mockHandler->append(new BadResponseException('Not found', new Request('get', 'https://www.whatever.com'), new Response(404)));
+        $this->mockHandler->append(new BadResponseException('Not found', new Request('GET', 'https://www.whatever.com'), new Response(404)));
         $response = $this->client->request('POST', 'https://www.whatever.com', ['myquerykey' => 'myqueryvalue'], ['myparamkey' => 'myparamvalue']);
         $this->assertNull($response->getContent());
         $this->assertSame(404, $response->getStatusCode());
@@ -135,14 +135,14 @@ final class GuzzleClientTest extends UnitTest {
     }
 
     public function testPostMethodThatThrowsException(): void {
-        $this->mockHandler->append(new RequestException('Not found', new Request('get', 'https://www.whatever.com')));
+        $this->mockHandler->append(new RequestException('Not found', new Request('GET', 'https://www.whatever.com')));
         $this->expectException(HttpException::class, 'Unable to complete the HTTP request');
         $this->client->request('POST', 'https://www.whatever.com', ['myquerykey' => 'myqueryvalue'], ['myparamkey' => 'myparamvalue']);
     }
 
     public function testQueryParams(): void {
         $this->mockHandler->append(new Response());
-        $this->client->request('get', 'https://www.whatever.com?foo=bar');
+        $this->client->request('GET', 'https://www.whatever.com?foo=bar');
         $request = $this->mockHandler->getLastRequest();
 
         $this->assertSame('https://www.whatever.com?foo=bar', (string)$request->getUri());

--- a/tests/Twilio/Unit/VersionTest.php
+++ b/tests/Twilio/Unit/VersionTest.php
@@ -393,7 +393,7 @@ class VersionTest extends UnitTest {
                                         "foo": "bar" }
                                     }'));
         try {
-            $this->version->handleRequest('get', 'http://foo.bar' , [], [], [], "fetch");
+            $this->version->handleRequest('GET', 'http://foo.bar' , [], [], [], "fetch");
             self::fail();
         }catch (RestException $rex){
             self::assertEquals(20001, $rex->getCode());
@@ -415,7 +415,7 @@ class VersionTest extends UnitTest {
                                     "status": 400
                                     }'));
         try {
-            $this->version->handleRequest('get', 'http://foo.bar', [], [], [], "fetch");
+            $this->version->handleRequest('GET', 'http://foo.bar', [], [], [], "fetch");
             self::fail();
         }catch (RestException $rex){
             self::assertEquals(20001, $rex->getCode());
@@ -432,7 +432,7 @@ class VersionTest extends UnitTest {
             ->method('request')
             ->willReturn(new Response(400, ''));
         try {
-            $this->version->handleRequest('get', 'http://foo.bar', [], [], [], "fetch");
+            $this->version->handleRequest('GET', 'http://foo.bar', [], [], [], "fetch");
             self::fail();
         }catch (RestException $rex){
             self::assertEquals(400, $rex->getCode());
@@ -457,7 +457,7 @@ class VersionTest extends UnitTest {
                                     }'));
         try {
             $this->version = new ApiV1Version($this->version->getDomain(), $this->version->version);
-            $this->version->handleRequest('get', 'http://foo.bar', [], [], [], "fetch");
+            $this->version->handleRequest('GET', 'http://foo.bar', [], [], [], "fetch");
             self::fail();
         }catch (RestExceptionV1 $rex){
             self::assertEquals(20404, $rex->getCode());
@@ -475,7 +475,7 @@ class VersionTest extends UnitTest {
             ->willReturn(new Response(400, ''));
         try {
             $this->version = new ApiV1Version($this->version->getDomain(), $this->version->version);
-            $this->version->handleRequest('get', 'http://foo.bar', [], [], [], "fetch");
+            $this->version->handleRequest('GET', 'http://foo.bar', [], [], [], "fetch");
             self::fail();
         }catch (RestExceptionV1 $rex){
             self::assertEquals(400, $rex->getCode());


### PR DESCRIPTION
Update lowercase HTTP methods to uppercase. The reason for this is that these are case sensitive according to the spec, and we are using the wrong case. Guzzle's PSR7 2.x library silently converts to uppercase, however from 2.11.0 I have added a deprecation warning that this behaviour is stopping, and 3.0.0 will no longer do this.