### PR TITLE
Validate HTTP request headers

### DIFF
--- a/src/Twilio/Base/BaseClient.php
+++ b/src/Twilio/Base/BaseClient.php
@@ -7,6 +7,7 @@ use Twilio\Exceptions\ConfigurationException;
 use Twilio\Exceptions\TwilioException;
 use Twilio\Http\Client as HttpClient;
 use Twilio\Http\CurlClient;
+use Twilio\Http\RequestHeaders;
 use Twilio\Rest\Api;
 use Twilio\Security\RequestValidator;
 use Twilio\VersionInfo;
@@ -187,6 +188,8 @@ class BaseClient
         if ($method !== "DELETE" && !\array_key_exists('Accept', $headers)) {
             $headers['Accept'] = 'application/json';
         }
+
+        $headers = RequestHeaders::validate($headers);
 
         $uri = $this->buildUri($uri);
 

--- a/src/Twilio/Http/CurlClient.php
+++ b/src/Twilio/Http/CurlClient.php
@@ -101,9 +101,10 @@ class CurlClient implements Client {
             CURLOPT_PROTOCOLS => CURLPROTO_HTTPS | CURLPROTO_HTTP
         ];
 
-        foreach ($headers as $key => $value) {
-            $options[CURLOPT_HTTPHEADER][] = "$key: $value";
-        }
+        $options[CURLOPT_HTTPHEADER] = \array_merge(
+            $options[CURLOPT_HTTPHEADER],
+            RequestHeaders::toCurlHeaders($headers)
+        );
 
         if ($user && $password) {
             $options[CURLOPT_HTTPHEADER][] = 'Authorization: Basic ' . \base64_encode("$user:$password");

--- a/src/Twilio/Http/GuzzleClient.php
+++ b/src/Twilio/Http/GuzzleClient.php
@@ -25,6 +25,8 @@ final class GuzzleClient implements Client {
                             array $params = [], array $data = [], array $headers = [],
                             ?string $user = null, ?string $password = null,
                             ?int $timeout = null, ?AuthStrategy $authStrategy = null): Response {
+        $headers = RequestHeaders::validate($headers);
+
         try {
             $options = [
                 'timeout' => $timeout,

--- a/src/Twilio/Http/RequestHeaders.php
+++ b/src/Twilio/Http/RequestHeaders.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace Twilio\Http;
+
+
+final class RequestHeaders {
+    private function __construct() {}
+
+    public static function validate(array $headers): array {
+        foreach ($headers as $name => $value) {
+            if (!\is_string($name) || $name === '') {
+                throw new \InvalidArgumentException('Header names must be non-empty strings.');
+            }
+
+            if (!\is_string($value)) {
+                throw new \InvalidArgumentException('Header values must be strings.');
+            }
+        }
+
+        return $headers;
+    }
+
+    public static function toCurlHeaders(array $headers): array {
+        $result = [];
+
+        foreach (self::validate($headers) as $name => $value) {
+            $result[] = $name . ': ' . $value;
+        }
+
+        return $result;
+    }
+}

--- a/tests/Twilio/Unit/Http/CurlClientTest.php
+++ b/tests/Twilio/Unit/Http/CurlClientTest.php
@@ -81,6 +81,33 @@ class CurlClientTest extends UnitTest {
         $this->assertEquals($headers, ["Authorization: "]);
     }
 
+    public function testHeaderStringValueIsAccepted(): void {
+        $client = new CurlClient();
+        $options = $client->options('GET', 'url', [], [], [
+            'X-Test' => 'value',
+        ]);
+
+        $this->assertContains('X-Test: value', $options[CURLOPT_HTTPHEADER]);
+    }
+
+    public function testRejectsNonStringHeaderValue(): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header values must be strings.');
+
+        (new CurlClient())->options('GET', 'url', [], [], [
+            'X-Test' => 123,
+        ]);
+    }
+
+    public function testRejectsArrayHeaderValue(): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header values must be strings.');
+
+        (new CurlClient())->options('GET', 'url', [], [], [
+            'X-Test' => ['value'],
+        ]);
+    }
+
     public function buildQueryProvider(): array {
         return [
             [

--- a/tests/Twilio/Unit/Http/GuzzleClientTest.php
+++ b/tests/Twilio/Unit/Http/GuzzleClientTest.php
@@ -86,6 +86,36 @@ final class GuzzleClientTest extends UnitTest {
         $this->assertSame([], $response->getHeaders());
     }
 
+    public function testHeaderStringValueIsAccepted(): void {
+        $this->mockHandler->append(new Response());
+
+        $this->client->request('GET', 'https://www.whatever.com', [], [], [
+            'X-Test' => 'value',
+        ]);
+
+        $request = $this->mockHandler->getLastRequest();
+
+        $this->assertSame(['value'], $request->getHeader('X-Test'));
+    }
+
+    public function testRejectsNonStringHeaderValue(): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header values must be strings.');
+
+        $this->client->request('GET', 'https://www.whatever.com', [], [], [
+            'X-Test' => 123,
+        ]);
+    }
+
+    public function testRejectsArrayHeaderValue(): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header values must be strings.');
+
+        $this->client->request('GET', 'https://www.whatever.com', [], [], [
+            'X-Test' => ['value'],
+        ]);
+    }
+
     public function testPostMethodArray(): void {
         $this->mockHandler->append(new Response());
         $response = $this->client->request('POST', 'https://www.whatever.com', [], ['key' => ['value1', 'value2']]);

--- a/tests/Twilio/Unit/Http/RequestHeadersTest.php
+++ b/tests/Twilio/Unit/Http/RequestHeadersTest.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Twilio\Tests\Unit\Http;
+
+
+use Twilio\Http\RequestHeaders;
+use Twilio\Tests\Unit\UnitTest;
+
+final class RequestHeadersTest extends UnitTest {
+    public function testValidatesStringHeaderValues(): void {
+        $headers = ['X-Test' => 'value'];
+
+        $this->assertSame($headers, RequestHeaders::validate($headers));
+    }
+
+    public function testRejectsEmptyHeaderName(): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header names must be non-empty strings.');
+
+        RequestHeaders::validate(['' => 'value']);
+    }
+}

--- a/tests/Twilio/Unit/Rest/ClientTest.php
+++ b/tests/Twilio/Unit/Rest/ClientTest.php
@@ -54,6 +54,17 @@ class ClientTest extends UnitTest {
         $this->assertEquals("", $client->getUsername());
     }
 
+    public function testRejectsNonStringHeaderValue(): void {
+        $client = new Client('username', 'password', null, null, new Holodeck());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header values must be strings.');
+
+        $client->request('GET', 'https://api.twilio.com', [], [], [
+            'X-Test' => 123,
+        ]);
+    }
+
     public function testUsernamePulledFromEnvironment(): void {
         $client = new Client(null, 'password', null, null, null, [
             Client::ENV_ACCOUNT_SID => 'username',


### PR DESCRIPTION
This is a defence in depth PR to make sure that the header names are non-empty-strings and values are strings. Guzzle's PSR-7 2.x library will start to get more fussy about this from 2.11.0 by triggering deprecation errors, and 3.0.0 will throw InvalidArgumentException. The best approach I think is that the Twilio code does its own validation. I audited the code paths, and all your code should already be passing valid headers.