### PR TITLE
Correct minimum PHP version to 7.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=7.2.5"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3 || ^7.0",


### PR DESCRIPTION
This aligns Composer's minimum PHP requirement with the documented supported PHP versions. I checked the current code, and it actually does not work on PHP 7.1 with syntax errors, so this is not just a theoretical documentation alignment issue. CI also does not run against PHP 7.1. The reason for 7.2.5 is that 7.2.5 ships with Ubuntu 18.04 and earlier versions have bad bugs - very many PHP packages including Symfony and Guzzle use 7.2.5 as a floor instead of 7.2 for this reason.