### PR TITLE
Fix generated PHP 7.2 syntax

### DIFF
--- a/src/Twilio/Rest/Conversations/V2/CommunicationList.php
+++ b/src/Twilio/Rest/Conversations/V2/CommunicationList.php
@@ -242,8 +242,7 @@ class CommunicationList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -274,11 +273,10 @@ class CommunicationList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): CommunicationPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new CommunicationPage($this->version, $response, $this->solution);
     }
@@ -293,11 +291,10 @@ class CommunicationList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new CommunicationPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Conversations/V2/ConfigurationList.php
+++ b/src/Twilio/Rest/Conversations/V2/ConfigurationList.php
@@ -235,8 +235,7 @@ class ConfigurationList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -267,11 +266,10 @@ class ConfigurationList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ConfigurationPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ConfigurationPage($this->version, $response, $this->solution);
     }
@@ -286,11 +284,10 @@ class ConfigurationList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ConfigurationPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Conversations/V2/ConversationList.php
+++ b/src/Twilio/Rest/Conversations/V2/ConversationList.php
@@ -231,8 +231,7 @@ class ConversationList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -265,11 +264,10 @@ class ConversationList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ConversationPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ConversationPage($this->version, $response, $this->solution);
     }
@@ -284,11 +282,10 @@ class ConversationList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ConversationPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Conversations/V2/ParticipantList.php
+++ b/src/Twilio/Rest/Conversations/V2/ParticipantList.php
@@ -242,8 +242,7 @@ class ParticipantList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -272,11 +271,10 @@ class ParticipantList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ParticipantPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ParticipantPage($this->version, $response, $this->solution);
     }
@@ -291,11 +289,10 @@ class ParticipantList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ParticipantPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Intelligence/V3/ConfigurationList.php
+++ b/src/Twilio/Rest/Intelligence/V3/ConfigurationList.php
@@ -233,8 +233,7 @@ class ConfigurationList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -263,11 +262,10 @@ class ConfigurationList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ConfigurationPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ConfigurationPage($this->version, $response, $this->solution);
     }
@@ -282,11 +280,10 @@ class ConfigurationList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ConfigurationPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Intelligence/V3/ConversationList.php
+++ b/src/Twilio/Rest/Intelligence/V3/ConversationList.php
@@ -172,8 +172,7 @@ class ConversationList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -218,11 +217,10 @@ class ConversationList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ConversationPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ConversationPage($this->version, $response, $this->solution);
     }
@@ -237,11 +235,10 @@ class ConversationList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ConversationPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Intelligence/V3/OperatorList.php
+++ b/src/Twilio/Rest/Intelligence/V3/OperatorList.php
@@ -233,8 +233,7 @@ class OperatorList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -263,11 +262,10 @@ class OperatorList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): OperatorPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new OperatorPage($this->version, $response, $this->solution);
     }
@@ -282,11 +280,10 @@ class OperatorList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new OperatorPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Intelligence/V3/OperatorResultList.php
+++ b/src/Twilio/Rest/Intelligence/V3/OperatorResultList.php
@@ -171,8 +171,7 @@ class OperatorResultList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -207,11 +206,10 @@ class OperatorResultList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): OperatorResultPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new OperatorResultPage($this->version, $response, $this->solution);
     }
@@ -226,11 +224,10 @@ class OperatorResultList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new OperatorResultPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Intelligence/V3/VersionList.php
+++ b/src/Twilio/Rest/Intelligence/V3/VersionList.php
@@ -177,8 +177,7 @@ class VersionList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -207,11 +206,10 @@ class VersionList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): VersionPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new VersionPage($this->version, $response, $this->solution);
     }
@@ -226,11 +224,10 @@ class VersionList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new VersionPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Knowledge/V2/ChunkList.php
+++ b/src/Twilio/Rest/Knowledge/V2/ChunkList.php
@@ -183,8 +183,7 @@ class ChunkList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -213,11 +212,10 @@ class ChunkList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ChunkPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ChunkPage($this->version, $response, $this->solution);
     }
@@ -232,11 +230,10 @@ class ChunkList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ChunkPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Knowledge/V2/KnowledgeBasisList.php
+++ b/src/Twilio/Rest/Knowledge/V2/KnowledgeBasisList.php
@@ -233,8 +233,7 @@ class KnowledgeBasisList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -265,11 +264,10 @@ class KnowledgeBasisList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): KnowledgeBasisPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new KnowledgeBasisPage($this->version, $response, $this->solution);
     }
@@ -284,11 +282,10 @@ class KnowledgeBasisList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new KnowledgeBasisPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Knowledge/V2/KnowledgeList.php
+++ b/src/Twilio/Rest/Knowledge/V2/KnowledgeList.php
@@ -245,8 +245,7 @@ class KnowledgeList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -277,11 +276,10 @@ class KnowledgeList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): KnowledgePage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new KnowledgePage($this->version, $response, $this->solution);
     }
@@ -296,11 +294,10 @@ class KnowledgeList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new KnowledgePage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/ConversationSummaryList.php
+++ b/src/Twilio/Rest/Memory/V1/ConversationSummaryList.php
@@ -262,8 +262,7 @@ class ConversationSummaryList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -294,11 +293,10 @@ class ConversationSummaryList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ConversationSummaryPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ConversationSummaryPage($this->version, $response, $this->solution);
     }
@@ -313,11 +311,10 @@ class ConversationSummaryList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ConversationSummaryPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/DataMappingList.php
+++ b/src/Twilio/Rest/Memory/V1/DataMappingList.php
@@ -245,8 +245,7 @@ class DataMappingList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -279,11 +278,10 @@ class DataMappingList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): DataMappingPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new DataMappingPage($this->version, $response, $this->solution);
     }
@@ -298,11 +296,10 @@ class DataMappingList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new DataMappingPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/IdentifierList.php
+++ b/src/Twilio/Rest/Memory/V1/IdentifierList.php
@@ -249,8 +249,7 @@ class IdentifierList extends ListResource
      * @return Response Paged Response
      */
     private function _page(
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
 
@@ -272,11 +271,10 @@ class IdentifierList extends ListResource
      * @return IdentifierPage Page of IdentifierInstance
      */
     public function page(
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): IdentifierPage
     {
-        $response = $this->_page( $pageSize,);
+        $response = $this->_page($pageSize);
 
         return new IdentifierPage($this->version, $response, $this->solution);
     }
@@ -290,11 +288,10 @@ class IdentifierList extends ListResource
      * @return PageMetadata of IdentifierInstance
      */
     public function pageWithMetadata(
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page( $pageSize,);
+        $response = $this->_page($pageSize);
 
         $resource =  new IdentifierPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/ImportList.php
+++ b/src/Twilio/Rest/Memory/V1/ImportList.php
@@ -237,8 +237,7 @@ class ImportList extends ListResource
      * @return Response Paged Response
      */
     private function _page(
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
 
@@ -260,11 +259,10 @@ class ImportList extends ListResource
      * @return ImportPage Page of ImportInstance
      */
     public function page(
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ImportPage
     {
-        $response = $this->_page( $pageSize,);
+        $response = $this->_page($pageSize);
 
         return new ImportPage($this->version, $response, $this->solution);
     }
@@ -278,11 +276,10 @@ class ImportList extends ListResource
      * @return PageMetadata of ImportInstance
      */
     public function pageWithMetadata(
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page( $pageSize,);
+        $response = $this->_page($pageSize);
 
         $resource =  new ImportPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/ObservationList.php
+++ b/src/Twilio/Rest/Memory/V1/ObservationList.php
@@ -263,8 +263,7 @@ class ObservationList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -303,11 +302,10 @@ class ObservationList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ObservationPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ObservationPage($this->version, $response, $this->solution);
     }
@@ -322,11 +320,10 @@ class ObservationList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ObservationPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/ProfileList.php
+++ b/src/Twilio/Rest/Memory/V1/ProfileList.php
@@ -245,8 +245,7 @@ class ProfileList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -277,11 +276,10 @@ class ProfileList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): ProfilePage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new ProfilePage($this->version, $response, $this->solution);
     }
@@ -296,11 +294,10 @@ class ProfileList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new ProfilePage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/RevisionList.php
+++ b/src/Twilio/Rest/Memory/V1/RevisionList.php
@@ -189,8 +189,7 @@ class RevisionList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -221,11 +220,10 @@ class RevisionList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): RevisionPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new RevisionPage($this->version, $response, $this->solution);
     }
@@ -240,11 +238,10 @@ class RevisionList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new RevisionPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/StoreList.php
+++ b/src/Twilio/Rest/Memory/V1/StoreList.php
@@ -233,8 +233,7 @@ class StoreList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -265,11 +264,10 @@ class StoreList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): StorePage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new StorePage($this->version, $response, $this->solution);
     }
@@ -284,11 +282,10 @@ class StoreList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new StorePage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/TraitGroupList.php
+++ b/src/Twilio/Rest/Memory/V1/TraitGroupList.php
@@ -243,8 +243,7 @@ class TraitGroupList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -277,11 +276,10 @@ class TraitGroupList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): TraitGroupPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new TraitGroupPage($this->version, $response, $this->solution);
     }
@@ -296,11 +294,10 @@ class TraitGroupList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new TraitGroupPage($this->version, $response, $this->solution);
 

--- a/src/Twilio/Rest/Memory/V1/TraitList.php
+++ b/src/Twilio/Rest/Memory/V1/TraitList.php
@@ -183,8 +183,7 @@ class TraitList extends ListResource
      */
     private function _page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): Response
     {
         $options = new Values($options);
@@ -217,11 +216,10 @@ class TraitList extends ListResource
      */
     public function page(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): TraitPage
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         return new TraitPage($this->version, $response, $this->solution);
     }
@@ -236,11 +234,10 @@ class TraitList extends ListResource
      */
     public function pageWithMetadata(
         array $options = [],
-        $pageSize = Values::NONE,
-        
+        $pageSize = Values::NONE
     ): PageMetadata
     {
-        $response = $this->_page($options, $pageSize,);
+        $response = $this->_page($options, $pageSize);
 
         $resource =  new TraitPage($this->version, $response, $this->solution);
 


### PR DESCRIPTION
This removes trailing commas from generated REST list methods so they remain parseable on supported PHP versions. The trailing comma in that position is invalid syntax on PHP 7.2, and is not caught by CI because these files are not covered by tests.