### PR TITLE
Fix generated instance payload fallbacks

### DIFF
--- a/src/Twilio/Rest/Numbers/V1/PortingWebhookConfigurationDeleteInstance.php
+++ b/src/Twilio/Rest/Numbers/V1/PortingWebhookConfigurationDeleteInstance.php
@@ -19,6 +19,7 @@ namespace Twilio\Rest\Numbers\V1;
 
 use Twilio\Exceptions\TwilioException;
 use Twilio\InstanceResource;
+use Twilio\Values;
 use Twilio\Version;
 
 
@@ -34,6 +35,11 @@ class PortingWebhookConfigurationDeleteInstance extends InstanceResource
     public function __construct(Version $version, array $payload, ?string $webhookType = null)
     {
         parent::__construct($version);
+
+        // Marshaled Properties
+        $this->properties = [
+            'webhookType' => Values::array_get($payload, 'webhook_type'),
+        ];
 
         $this->solution = ['webhookType' => $webhookType ?: $this->properties['webhookType'], ];
     }
@@ -103,4 +109,3 @@ class PortingWebhookConfigurationDeleteInstance extends InstanceResource
         return '[Twilio.Numbers.V1.PortingWebhookConfigurationDeleteInstance ' . \implode(' ', $context) . ']';
     }
 }
-

--- a/src/Twilio/Rest/PreviewIam/Versionless/OrganizationInstance.php
+++ b/src/Twilio/Rest/PreviewIam/Versionless/OrganizationInstance.php
@@ -19,6 +19,7 @@ namespace Twilio\Rest\PreviewIam\Versionless;
 
 use Twilio\Exceptions\TwilioException;
 use Twilio\InstanceResource;
+use Twilio\Values;
 use Twilio\Version;
 use Twilio\Rest\PreviewIam\Versionless\Organization\AccountList;
 use Twilio\Rest\PreviewIam\Versionless\Organization\UserList;
@@ -43,6 +44,11 @@ class OrganizationInstance extends InstanceResource
     public function __construct(Version $version, array $payload, ?string $organizationSid = null)
     {
         parent::__construct($version);
+
+        // Marshaled Properties
+        $this->properties = [
+            'organizationSid' => Values::array_get($payload, 'organization_sid') ?: Values::array_get($payload, 'id'),
+        ];
 
         $this->solution = ['organizationSid' => $organizationSid ?: $this->properties['organizationSid'], ];
     }
@@ -144,4 +150,3 @@ class OrganizationInstance extends InstanceResource
         return '[Twilio.PreviewIam.Versionless.OrganizationInstance ' . \implode(' ', $context) . ']';
     }
 }
-

--- a/src/Twilio/Rest/Voice/V1/ArchivedCallContext.php
+++ b/src/Twilio/Rest/Voice/V1/ArchivedCallContext.php
@@ -114,6 +114,10 @@ class ArchivedCallContext extends InstanceContext
     {
         $context = [];
         foreach ($this->solution as $key => $value) {
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('Y-m-d');
+            }
+
             $context[] = "$key=$value";
         }
         return '[Twilio.Voice.V1.ArchivedCallContext ' . \implode(' ', $context) . ']';

--- a/src/Twilio/Rest/Voice/V1/ArchivedCallInstance.php
+++ b/src/Twilio/Rest/Voice/V1/ArchivedCallInstance.php
@@ -18,7 +18,9 @@
 namespace Twilio\Rest\Voice\V1;
 
 use Twilio\Exceptions\TwilioException;
+use Twilio\Deserialize;
 use Twilio\InstanceResource;
+use Twilio\Values;
 use Twilio\Version;
 
 
@@ -35,6 +37,12 @@ class ArchivedCallInstance extends InstanceResource
     public function __construct(Version $version, array $payload, ?\DateTime $date = null, ?string $sid = null)
     {
         parent::__construct($version);
+
+        // Marshaled Properties
+        $this->properties = [
+            'date' => Deserialize::dateTime(Values::array_get($payload, 'date')),
+            'sid' => Values::array_get($payload, 'sid'),
+        ];
 
         $this->solution = ['date' => $date ?: $this->properties['date'], 'sid' => $sid ?: $this->properties['sid'], ];
     }
@@ -100,9 +108,12 @@ class ArchivedCallInstance extends InstanceResource
     {
         $context = [];
         foreach ($this->solution as $key => $value) {
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('Y-m-d');
+            }
+
             $context[] = "$key=$value";
         }
         return '[Twilio.Voice.V1.ArchivedCallInstance ' . \implode(' ', $context) . ']';
     }
 }
-

--- a/tests/Twilio/Unit/Rest/GeneratedInstanceCompatibilityTest.php
+++ b/tests/Twilio/Unit/Rest/GeneratedInstanceCompatibilityTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Twilio\Tests\Unit\Rest;
+
+use Twilio\Domain;
+use Twilio\Http\CurlClient;
+use Twilio\Rest\Client;
+use Twilio\Rest\Numbers\V1\PortingWebhookConfigurationDeleteInstance;
+use Twilio\Rest\PreviewIam\Versionless\OrganizationInstance;
+use Twilio\Rest\Voice\V1\ArchivedCallContext;
+use Twilio\Rest\Voice\V1\ArchivedCallInstance;
+use Twilio\Tests\Unit\UnitTest;
+use Twilio\Version;
+
+class GeneratedInstanceCompatibilityTest extends UnitTest {
+    private function createVersion(): Version {
+        $client = new Client('username', 'password', null, null, $this->createMock(CurlClient::class), null);
+        $domain = new class($client) extends Domain {
+        };
+
+        return new class($domain) extends Version {
+        };
+    }
+
+    private function withoutWarnings(callable $callback) {
+        \set_error_handler(function (int $severity, string $message, string $file, int $line): void {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            return $callback();
+        } finally {
+            \restore_error_handler();
+        }
+    }
+
+    public function testPortingWebhookConfigurationDeleteInstanceUsesPayloadFallback(): void {
+        $output = $this->withoutWarnings(function (): string {
+            $instance = new PortingWebhookConfigurationDeleteInstance(
+                $this->createVersion(),
+                ['webhook_type' => 'PORT_IN']
+            );
+
+            return (string) $instance;
+        });
+
+        $this->assertSame('[Twilio.Numbers.V1.PortingWebhookConfigurationDeleteInstance webhookType=PORT_IN]', $output);
+    }
+
+    public function testOrganizationInstanceUsesPayloadFallback(): void {
+        $output = $this->withoutWarnings(function (): string {
+            $instance = new OrganizationInstance($this->createVersion(), ['id' => 'OR123']);
+
+            return (string) $instance;
+        });
+
+        $this->assertSame('[Twilio.PreviewIam.Versionless.OrganizationInstance organizationSid=OR123]', $output);
+    }
+
+    public function testOrganizationInstancePrefersOrganizationSidPayloadFallback(): void {
+        $output = $this->withoutWarnings(function (): string {
+            $instance = new OrganizationInstance(
+                $this->createVersion(),
+                ['organization_sid' => 'OR456', 'id' => 'OR123']
+            );
+
+            return (string) $instance;
+        });
+
+        $this->assertSame('[Twilio.PreviewIam.Versionless.OrganizationInstance organizationSid=OR456]', $output);
+    }
+
+    public function testArchivedCallInstanceUsesPayloadFallback(): void {
+        $output = $this->withoutWarnings(function (): string {
+            $instance = new ArchivedCallInstance(
+                $this->createVersion(),
+                ['date' => '2024-01-02', 'sid' => 'CA123']
+            );
+
+            return (string) $instance;
+        });
+
+        $this->assertSame('[Twilio.Voice.V1.ArchivedCallInstance date=2024-01-02 sid=CA123]', $output);
+    }
+
+    public function testArchivedCallInstanceStringifiesDateTimeSolution(): void {
+        $output = $this->withoutWarnings(function (): string {
+            $instance = new ArchivedCallInstance(
+                $this->createVersion(),
+                [],
+                new \DateTime('2024-01-02'),
+                'CA123'
+            );
+
+            return (string) $instance;
+        });
+
+        $this->assertSame('[Twilio.Voice.V1.ArchivedCallInstance date=2024-01-02 sid=CA123]', $output);
+    }
+
+    public function testArchivedCallContextStringifiesDateTimeSolution(): void {
+        $output = $this->withoutWarnings(function (): string {
+            $context = new ArchivedCallContext($this->createVersion(), new \DateTime('2024-01-02'), 'CA123');
+
+            return (string) $context;
+        });
+
+        $this->assertSame('[Twilio.Voice.V1.ArchivedCallContext date=2024-01-02 sid=CA123]', $output);
+    }
+}


### PR DESCRIPTION
This fixes generated instances that read solution values from uninitialized properties and makes archived call string output handle DateTime values.