### PR TITLE
Fix raw body validation without query strings

### DIFF
--- a/src/Twilio/Security/RequestValidator.php
+++ b/src/Twilio/Security/RequestValidator.php
@@ -83,9 +83,8 @@ class RequestValidator {
 
         if (!\is_array($data)) {
             // handling if the data was passed through as a string instead of an array of params
-            $queryString = \explode('?', $url);
-            $queryString = $queryString[1];
-            \parse_str($queryString, $params);
+            $params = [];
+            \parse_str($parsedUrl['query'] ?? '', $params);
 
             $validBodyHash = self::compare(self::computeBodyHash($data), Values::array_get($params, 'bodySHA256'));
             $data = [];

--- a/tests/Twilio/Unit/RequestValidatorTest.php
+++ b/tests/Twilio/Unit/RequestValidatorTest.php
@@ -23,6 +23,18 @@ class RequestValidatorTest extends UnitTest {
         $this->validator = new RequestValidator('12345');
     }
 
+    private function withoutWarnings(callable $callback) {
+        \set_error_handler(function (int $severity, string $message, string $file, int $line): void {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            return $callback();
+        } finally {
+            \restore_error_handler();
+        }
+    }
+
     public function testValidate(): void {
         $isValid = $this->validator->validate($this->signature, $this->url, $this->params);
         $this->assertTrue($isValid);
@@ -59,6 +71,18 @@ class RequestValidatorTest extends UnitTest {
 
     public function testValidateBodyWithoutSignature(): void {
         $isValid = $this->validator->validate($this->signature, $this->url, $this->body);
+
+        $this->assertFalse($isValid);
+    }
+
+    public function testValidateBodyWithoutQueryString(): void {
+        $isValid = $this->withoutWarnings(function (): bool {
+            return $this->validator->validate(
+                $this->signature,
+                'https://mycompany.com/myapp.php',
+                $this->body
+            );
+        });
 
         $this->assertFalse($isValid);
     }


### PR DESCRIPTION
This avoids an undefined query-string offset when validating raw request bodies for URLs without query parameters.