### PR TITLE
Fix ScopeURI parsing

### DIFF
--- a/src/Twilio/Jwt/Client/ScopeURI.php
+++ b/src/Twilio/Jwt/Client/ScopeURI.php
@@ -47,14 +47,14 @@ class ScopeURI {
                 'Not a scope URI according to scheme');
         }
 
-        $parts = \explode('?', $uri, 1);
-        $params = null;
+        $queryParts = \explode('?', $uri, 2);
+        $params = [];
 
-        if (\count($parts) > 1) {
-            \parse_str($parts[1], $params);
+        if (\count($queryParts) > 1) {
+            \parse_str($queryParts[1], $params);
         }
 
-        $parts = \explode(':', $parts[0], 2);
+        $parts = \explode(':', $queryParts[0]);
 
         if (\count($parts) !== 3) {
             throw new \UnexpectedValueException(

--- a/tests/Twilio/Unit/Jwt/Client/ScopeURITest.php
+++ b/tests/Twilio/Unit/Jwt/Client/ScopeURITest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Twilio\Tests\Unit\Jwt\Client;
+
+use Twilio\Jwt\Client\ScopeURI;
+use Twilio\Tests\Unit\UnitTest;
+
+class ScopeURITest extends UnitTest {
+    public function testParseWithParams(): void {
+        $scope = ScopeURI::parse('scope:client:incoming?clientName=andy');
+
+        $this->assertSame('client', $scope->service);
+        $this->assertSame('incoming', $scope->privilege);
+        $this->assertSame(['clientName' => 'andy'], $scope->params);
+        $this->assertSame('scope:client:incoming?clientName=andy', $scope->toString());
+    }
+
+    public function testParseWithoutParams(): void {
+        $scope = ScopeURI::parse('scope:client:incoming');
+
+        $this->assertSame('client', $scope->service);
+        $this->assertSame('incoming', $scope->privilege);
+        $this->assertSame([], $scope->params);
+        $this->assertSame('scope:client:incoming', $scope->toString());
+    }
+
+    public function testParseEncodedParams(): void {
+        $scope = ScopeURI::parse('scope:client:outgoing?appSid=AP123&appParams=foobar%3D3');
+
+        $this->assertSame('client', $scope->service);
+        $this->assertSame('outgoing', $scope->privilege);
+        $this->assertSame(['appSid' => 'AP123', 'appParams' => 'foobar=3'], $scope->params);
+        $this->assertSame('scope:client:outgoing?appSid=AP123&appParams=foobar%3D3', $scope->toString());
+    }
+
+    public function testParseRejectsNonScopeUri(): void {
+        $this->expectException(\UnexpectedValueException::class);
+
+        ScopeURI::parse('client:incoming?clientName=andy');
+    }
+
+    public function testParseRejectsIncompleteScopeUri(): void {
+        $this->expectException(\UnexpectedValueException::class);
+
+        ScopeURI::parse('scope:client');
+    }
+
+    public function testParseRejectsTooManyScopeParts(): void {
+        $this->expectException(\UnexpectedValueException::class);
+
+        ScopeURI::parse('scope:client:incoming:extra');
+    }
+}


### PR DESCRIPTION
This fixes ScopeURI parsing for valid scope URIs with or without query parameters.