### PR TITLE
fix: use PHP 7.4 for phpdox docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,11 @@ test-docker:
 	docker run twilio/twilio-php phpunit -d memory_limit=512M --disallow-test-output --colors --configuration tests/phpunit.xml
 
 PHPDOX_PHAR=phpdox.phar
+PHP74 = $(shell command -v /opt/homebrew/opt/php@7.4/bin/php 2>/dev/null || echo php)
 docs-install:
 
 docs:
-	php ${PHPDOX_PHAR}
+	${PHP74} ${PHPDOX_PHAR}
 
 authors:
 	echo "Authors\n=======\n\nA huge thanks to all of our contributors:\n\n" > AUTHORS.md

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Twilio API helper library.
 # See LICENSE file for copyright and license details.
-.PHONY: all clean install test test-docker docs authors docker-dev-build docker-dev-clean docker-dev-test
+.PHONY: all clean install test test-docker docs docs-new authors docker-dev-build docker-dev-clean docker-dev-test
 
 COMPOSER = $(shell which composer)
 ifeq ($(strip $(COMPOSER)),)
@@ -32,6 +32,10 @@ docs-install:
 
 docs:
 	${PHP74} ${PHPDOX_PHAR}
+
+# phpDocumentor: alternative to phpdox, works with PHP 8.x (no PHP 7.4 required)
+docs-new:
+	docker run --rm -v $(PWD):/data phpdoc/phpdoc -d /data/src -t /data/docs/api
 
 authors:
 	echo "Authors\n=======\n\nA huge thanks to all of our contributors:\n\n" > AUTHORS.md

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,10 @@ docs-install:
 docs:
 	${PHP74} ${PHPDOX_PHAR}
 
+PHPDOC_PHAR=phpDocumentor.phar
 # phpDocumentor: alternative to phpdox, works with PHP 8.x (no PHP 7.4 required)
 docs-new:
-	docker run --rm -v $(PWD):/data phpdoc/phpdoc -d /data/src -t /data/docs/api
+	php ${PHPDOC_PHAR} -d src/ -t docs/api
 
 authors:
 	echo "Authors\n=======\n\nA huge thanks to all of our contributors:\n\n" > AUTHORS.md

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ clean:
 install: clean
 	@composer --version || (curl -s https://getcomposer.org/installer | php);
 	$(COMPOSER) install
+	@test -f phpDocumentor.phar || curl -sL https://phpdoc.org/phpDocumentor.phar -o phpDocumentor.phar
 
 vendor: install
 


### PR DESCRIPTION
## Summary

- phpdox 0.12.0 is incompatible with PHP 8.x — static method signature changes in PHP 8.0 and removal of `E_STRICT` in PHP 8.4 cause fatal errors
- twilio-php supports PHP 8.2, 8.3, 8.4 so the system `php` binary always hits this issue
- Add a `PHP74` variable that resolves to `/opt/homebrew/opt/php@7.4/bin/php` when available (via `brew install php@7.4`), falling back to `php` if not
- `make docs` now uses `${PHP74}` instead of hardcoded `php`

phpdox generates- 
<img width="1169" height="501" alt="image" src="https://github.com/user-attachments/assets/1ded3cd4-fbc8-45d6-9b47-58552eb08294" />
phpDocumenter generates- 
<img width="1595" height="898" alt="image" src="https://github.com/user-attachments/assets/d54523bb-2370-4ac8-87ca-dbbc8db2ecfa" />

extra section - files/, graphs/, images/, indices/, packages/, reports/


## Test plan

- [ ] `brew install php@7.4`
- [ ] Run `make docs` and verify HTML files are generated in `docs/api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)